### PR TITLE
docs: add Claude Code setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ fun easy tl;dr version of the change logs: [`Nomit Memento`](https://nomit.dev/c
 
 - Project docs: [`docs/README.md`](./docs/README.md)
 - Generic MCP clients: [`docs/clients.md`](./docs/clients.md)
+- Claude Code and Claude Desktop setup: [`docs/clients.md#claude-code`](./docs/clients.md#claude-code)
 - VS Code usage: [`docs/vscode.md`](./docs/vscode.md)
 - VS Code extension: [`vscode-extension/README.md`](./vscode-extension/README.md)
 - ADR guide: [`docs/adr/README.md`](./docs/adr/README.md)
@@ -77,6 +78,16 @@ make build
 ./bin/memento-mcp print-config
 ./bin/memento-mcp print-guidance
 ```
+
+### Claude Code Quick Start
+
+After building or installing `memento-mcp`, add it to Claude Code as a stdio MCP server:
+
+```bash
+claude mcp add memento-mcp -- /absolute/path/to/memento-mcp
+```
+
+For project-scoped setup and Claude Desktop import notes, see [`docs/clients.md`](./docs/clients.md#claude-code).
 
 ### Run Tests
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -16,6 +16,7 @@ Um servidor MCP local-first que oferece aos agentes de IA uma memória durável 
 ## Documentação
 
 - Docs do projeto: [`docs/README.md`](./docs/README.md)
+- Clientes MCP genéricos, Claude Code e Claude Desktop: [`docs/clients.md`](./docs/clients.md)
 - Uso com VS Code: [`docs/vscode.md`](./docs/vscode.md)
 - Extensão VS Code: [`vscode-extension/README.md`](./vscode-extension/README.md)
 - Guia de ADR: [`docs/adr/README.md`](./docs/adr/README.md)
@@ -64,6 +65,23 @@ git clone https://github.com/caiowilson/MCP-memento.git
 cd MCP-memento
 make build
 ./bin/memento-mcp
+```
+
+### Início Rápido com Claude Code
+
+Depois de compilar ou instalar o `memento-mcp`, adicione-o ao Claude Code como um servidor MCP stdio:
+
+```bash
+claude mcp add memento-mcp -- /caminho/absoluto/para/memento-mcp
+```
+
+Para configuração com escopo de projeto e notas sobre Claude Desktop, veja [`docs/clients.md`](./docs/clients.md#claude-code).
+
+### Onboarding de Clientes Genéricos
+
+```bash
+./bin/memento-mcp print-config
+./bin/memento-mcp print-guidance
 ```
 
 ### Rodar Testes

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This directory collects the main project documentation, including client setup, 
 ## Contents
 
 - Getting started: `../README.md`
-- Generic MCP clients: `clients.md`
+- Generic MCP clients, Claude Code, and Claude Desktop: `clients.md`
 - VS Code usage: `vscode.md`
 - Canonical backlog: `../TODO.md`
 - VS Code extension: `../vscode-extension/README.md`

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -39,6 +39,77 @@ Show built-in help:
 
 If your MCP client expects a different JSON shape, reuse the same values for `command`, `args`, `cwd`, `env`, and stdio transport.
 
+## Claude Code
+
+After building or installing the server, the fastest global setup is:
+
+```bash
+claude mcp add memento-mcp -- /absolute/path/to/memento-mcp
+```
+
+Then verify it from Claude Code:
+
+```bash
+claude mcp list
+```
+
+You can also use `/mcp` inside Claude Code to inspect connected MCP servers.
+
+### Project-scoped `.mcp.json`
+
+For a project-local setup, commit a `.mcp.json` file at the project root and point `command` at the server binary you want the project to use:
+
+```json
+{
+  "mcpServers": {
+    "memento-mcp": {
+      "type": "stdio",
+      "command": "${CLAUDE_PROJECT_DIR:-.}/bin/memento-mcp",
+      "args": [],
+      "env": {
+        "MEMENTO_CHANGE_DETECTOR": "auto",
+        "MEMENTO_FS_DEBOUNCE_MS": "500",
+        "MEMENTO_GIT_DEBOUNCE_MS": "500",
+        "MEMENTO_GIT_POLL_SECONDS": "2",
+        "MEMENTO_INDEX_POLL_SECONDS": "10"
+      }
+    }
+  }
+}
+```
+
+Project-scoped MCP servers may prompt for approval the first time Claude Code sees them in a workspace. Keep the binary path stable so the approval and config remain useful across sessions.
+
+### Claude Desktop
+
+Claude Desktop uses the same stdio server values in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "memento-mcp": {
+      "command": "/absolute/path/to/memento-mcp",
+      "args": [],
+      "env": {
+        "MEMENTO_CHANGE_DETECTOR": "auto",
+        "MEMENTO_FS_DEBOUNCE_MS": "500",
+        "MEMENTO_GIT_DEBOUNCE_MS": "500",
+        "MEMENTO_GIT_POLL_SECONDS": "2",
+        "MEMENTO_INDEX_POLL_SECONDS": "10"
+      }
+    }
+  }
+}
+```
+
+On macOS and WSL, Claude Code can import Claude Desktop MCP servers:
+
+```bash
+claude mcp add-from-claude-desktop
+```
+
+Use `./bin/memento-mcp print-config` as the source of truth for the current generic `mcpServers` shape and environment defaults.
+
 ## Recommended LLM guidance
 
 Use the output of `print-guidance` directly, or paste the following into client instructions:


### PR DESCRIPTION
## Summary

- Add a Claude Code quick start to the English and pt-BR READMEs.
- Add Claude Code project-scoped `.mcp.json` guidance to `docs/clients.md`.
- Add a Claude Desktop stdio snippet and import note.
- Cross-link the client setup docs from `docs/README.md`.

Closes #19.

## Verification

- Ran `./bin/memento-mcp print-config` and matched the documented environment defaults to its output.
- Ran `./bin/memento-mcp print-guidance`.
- Ran `git diff --check`.
- Checked Markdown code fences in the touched docs.

Not run:

- `go test ./...` because Go is not installed in this environment.
