### PR TITLE
feat: add syntax-aware chunk boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ ChatGPT on the web does not load local Codex configuration or launch local STDIO
    - Configurable via `MEMENTO_CHANGE_DETECTOR` (`auto` / `fs` / `git`)
 4. Context tools combine:
    - Indexed chunks and scoring
+   - Declaration-aligned Go and JavaScript/TypeScript chunk boundaries, with bounded line fallback
    - Language-aware relationships (Go type analysis, TS/JS imports, and PHP Composer/symbol/Laravel references)
    - Hard byte and line limits for LLM context safety
 5. Explicit notes are stored separately as durable, repo-scoped memory.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -137,6 +137,7 @@ No macOS ou WSL, `claude mcp add-from-claude-desktop` pode importar esse servido
    - Repositórios sem Git: fallback com watcher do sistema de arquivos
 4. As ferramentas de contexto combinam:
    - Chunks indexados e pontuação
+   - Limites de chunk alinhados a declarações Go e JavaScript/TypeScript, com fallback limitado por linhas
    - Relacionamentos com conhecimento de linguagem (análise de tipos Go, imports TS/JS e referências Composer/símbolos/Laravel em PHP)
    - Limites rígidos de bytes e linhas para segurança do contexto de LLM
 5. Notas explícitas são armazenadas separadamente como memória durável com escopo do repositório.

--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,7 @@ Delivered by `91b6366` in `internal/indexing/chunk_test.go`.
 
 ### Slice 13 — Syntax-aware chunk boundaries
 
-- Status: todo
+- Status: done
 - Owner: @caiowilson
 - Difficulty: medium
 - Scope: `internal/indexing/chunk.go`
@@ -74,10 +74,12 @@ Chunks currently split at arbitrary line/byte boundaries and can cut functions i
 
 #### Steps
 
-- [ ] For Go files, use `go/ast` to split on top-level declaration boundaries (status: todo)
-- [ ] For JS/TS, detect function/class/export boundaries with regex heuristics (status: todo)
-- [ ] Fallback to line-based chunking for unknown languages (status: todo)
-- [ ] Add tests verifying Go chunks align to declaration boundaries (status: todo)
+- [x] For Go files, use `go/ast` to split on top-level declaration boundaries (status: done)
+- [x] For JS/TS, detect function/class/export boundaries with regex heuristics (status: done)
+- [x] Fallback to line-based chunking for unknown languages (status: done)
+- [x] Add tests verifying Go chunks align to declaration boundaries (status: done)
+
+Implemented in `internal/indexing/chunk.go` and `internal/indexing/syntax_chunk.go`, with persisted chunking fingerprints and regression coverage for syntax, fallback, redaction, and vector rebuild behavior.
 
 ### Slice 14A — `repo_diff_context` MVP (explicit paths)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ Configuration:
 - `MEMENTO_EMBEDDING_BATCH_SIZE` (default `32`)
 - `MEMENTO_EMBEDDING_TIMEOUT_SECONDS` (default `30`)
 
-Vector sidecars live under `~/.memento-mcp/repos/<repo-id>/index/v1/files/*.vec`. The embedding fingerprint is recorded in the manifest; changing the model removes incompatible vectors and re-embeds unchanged chunks during the next index pass. Prefer explicit model tags so cache invalidation is predictable.
+Vector sidecars live under `~/.memento-mcp/repos/<repo-id>/index/v1/files/*.vec`. The embedding fingerprint is recorded in the manifest; changing the model removes incompatible vectors and re-embeds unchanged chunks during the next index pass. The manifest also fingerprints the chunking algorithm and effective size limits. Upgrading to a release with new chunk boundaries triggers a one-time chunk rebuild and, when semantic retrieval is enabled, re-embedding. Prefer explicit model tags so cache invalidation is predictable.
 
 If Ollama is stopped or the model is absent, indexing and queries fall back to lexical retrieval. `repo_index_status` and `repo_index_debug` expose the embedding error, and Memento waits 30 seconds before retrying the unavailable runtime. Chunk indexing and all non-semantic tools continue to work.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -101,6 +101,8 @@ Thresholds and sample requirements live in `evaluation/fixtures/regression-gates
 
 Baseline refresh rationale for issue #30: the new feedback documentation moved the `MAX_MCP_OUTPUT_TOKENS` passage in `docs/README.md`, and review found that the paired `docs/clients.md` judgment also retained an older line number. Both judgments were moved to the current exact passage without changing their query or relevance meaning. The committed lexical baseline was regenerated after that anchor-only correction; no retrieval scoring behavior changed.
 
+Baseline refresh rationale for syntax-aware chunking: the chunk construction algorithm now prefers complete Go and JavaScript/TypeScript declarations, so the retrieval configuration fingerprint includes its version. The `ReloadIgnoreRules` judgments were moved to the current declaration and exact reference comment; the previous second judgment pointed at a nearby line that only overlapped under fixed-size chunking. The committed lexical baseline was regenerated against those intentional boundary and judgment changes; this is a retrieval-behavior change, not an anchor-only refresh.
+
 ## Validate the contract
 
 ```bash

--- a/evaluation/baselines/retrieval-ci-v1.json
+++ b/evaluation/baselines/retrieval-ci-v1.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
   "mode": "lexical",
-  "configurationFingerprint": "sha256:33e4116328f626f22ea771186ec17894004e28ac20e622e7e24a0c571298cd56",
-  "fixtureFingerprint": "sha256:a7684696dadd692912b9a228449572fcad202f36e3761471a2a8c48dc79989da",
+  "configurationFingerprint": "sha256:099fffde0a60d5ac1ab755c8e6c73262a181de6f00fca1c0807efea2dbb526b9",
+  "fixtureFingerprint": "sha256:60e2f8eb07e8a85f61eb86a15891bd2be125d854236a658a7a0caa834e0f46ca",
   "queryCount": 4,
   "k": 5,
   "metrics": {
-    "precision": 0.25,
-    "recall": 0.5416666666666666,
-    "mrr": 0.425,
-    "ndcg": 0.37007061612703984
+    "precision": 0.45,
+    "recall": 0.875,
+    "mrr": 1,
+    "ndcg": 0.8797931570750352
   }
 }

--- a/evaluation/fixtures/retrieval.json
+++ b/evaluation/fixtures/retrieval.json
@@ -6,8 +6,8 @@
       "id": "ignore-rule-reload",
       "query": "ReloadIgnoreRules",
       "relevant": [
-        { "path": "internal/indexing/indexer.go", "startLine": 136, "endLine": 137 },
-        { "path": "internal/indexing/indexer.go", "startLine": 641, "endLine": 641 },
+        { "path": "internal/indexing/indexer.go", "startLine": 138, "endLine": 139 },
+        { "path": "internal/indexing/indexer.go", "startLine": 650, "endLine": 650 },
         { "path": "internal/indexing/fs_change.go", "startLine": 142, "endLine": 142 }
       ]
     },

--- a/evaluation/retrieval_summary.go
+++ b/evaluation/retrieval_summary.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"memento-mcp/internal/indexing"
 )
 
 const RetrievalSummaryVersion = 1
@@ -24,6 +26,8 @@ type RetrievalSummaryConfig struct {
 	Mode           string
 	Embedder       string
 	SemanticWeight float64
+	MaxChunkLines  int
+	MaxChunkBytes  int
 }
 
 func NewRetrievalSummary(fixtures FixtureSet, report Report, cfg RetrievalSummaryConfig) (RetrievalSummary, error) {
@@ -37,8 +41,9 @@ func NewRetrievalSummary(fixtures FixtureSet, report Report, cfg RetrievalSummar
 			Mode           string  `json:"mode"`
 			Embedder       string  `json:"embedder,omitempty"`
 			SemanticWeight float64 `json:"semanticWeight,omitempty"`
+			Chunking       string  `json:"chunking"`
 			K              int     `json:"k"`
-		}{cfg.Mode, cfg.Embedder, cfg.SemanticWeight, report.K}),
+		}{cfg.Mode, cfg.Embedder, cfg.SemanticWeight, indexing.ChunkingFingerprint(cfg.MaxChunkLines, cfg.MaxChunkBytes), report.K}),
 		FixtureFingerprint: fingerprint(fixtures),
 		QueryCount:         len(report.Queries),
 		K:                  report.K,

--- a/evaluation/retrieval_summary_test.go
+++ b/evaluation/retrieval_summary_test.go
@@ -36,3 +36,19 @@ func TestRetrievalSummaryRoundTrip(t *testing.T) {
 		t.Fatalf("loaded = %#v, want %#v", loaded, summary)
 	}
 }
+
+func TestRetrievalSummaryFingerprintIncludesChunkLimits(t *testing.T) {
+	fixtures := FixtureSet{Version: 1, K: 5, Queries: []QueryFixture{{ID: "one", Query: "query", Relevant: []RelevantChunk{{Path: "README.md"}}}}}
+	report := Report{K: 5, Queries: []QueryResult{{ID: "one"}}}
+	defaults, err := NewRetrievalSummary(fixtures, report, RetrievalSummaryConfig{Mode: "lexical"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	custom, err := NewRetrievalSummary(fixtures, report, RetrievalSummaryConfig{Mode: "lexical", MaxChunkLines: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaults.ConfigurationFingerprint == custom.ConfigurationFingerprint {
+		t.Fatal("expected effective chunking limits to affect the retrieval configuration fingerprint")
+	}
+}

--- a/internal/indexing/chunk.go
+++ b/internal/indexing/chunk.go
@@ -1,9 +1,30 @@
 package indexing
 
 import (
-	"bufio"
+	"fmt"
 	"strings"
 )
+
+// ChunkingVersion identifies the persisted chunk-boundary algorithm. Change it
+// whenever identical source and limits can produce different ranges.
+const ChunkingVersion = "syntax-v1"
+
+const (
+	DefaultMaxChunkLines = 200
+	DefaultMaxChunkBytes = 8 * 1024
+)
+
+// ChunkingFingerprint returns the persisted identity for an algorithm and its
+// effective limits. Zero or negative limits resolve to the production defaults.
+func ChunkingFingerprint(maxLines, maxBytes int) string {
+	if maxLines <= 0 {
+		maxLines = DefaultMaxChunkLines
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxChunkBytes
+	}
+	return fmt.Sprintf("%s:max-lines=%d:max-bytes=%d", ChunkingVersion, maxLines, maxBytes)
+}
 
 type Chunk struct {
 	Path      string `json:"path"`
@@ -14,57 +35,167 @@ type Chunk struct {
 	Score     int    `json:"score,omitempty"`
 }
 
+// ChunkFile chunks content using syntax boundaries when the language supports
+// them. Callers that redact content before persistence should use
+// chunkFileWithSyntaxSource so parsing can still use the original source.
 func ChunkFile(path, language, content string, maxLines, maxBytes int) []Chunk {
+	return chunkFileWithSyntaxSource(path, language, content, content, maxLines, maxBytes)
+}
+
+func chunkFileWithSyntaxSource(path, language, content, syntaxSource string, maxLines, maxBytes int) []Chunk {
 	if maxLines <= 0 {
-		maxLines = 200
+		maxLines = DefaultMaxChunkLines
 	}
 	if maxBytes <= 0 {
-		maxBytes = 8 * 1024
+		maxBytes = DefaultMaxChunkBytes
 	}
 
-	sc := bufio.NewScanner(strings.NewReader(content))
-	sc.Buffer(make([]byte, 1024), maxBytes*4)
+	lines := splitChunkLines(content)
+	if len(lines) == 0 {
+		return nil
+	}
+	syntaxLines := splitChunkLines(syntaxSource)
+	if len(syntaxLines) != len(lines) {
+		return chunkLineRange(path, language, lines, 1, len(lines), maxLines, maxBytes)
+	}
 
-	var chunks []Chunk
-	var b strings.Builder
-	b.Grow(min(maxBytes, 4096))
+	starts, ok := syntaxChunkStarts(path, language, syntaxSource, syntaxLines)
+	if !ok || len(starts) == 0 {
+		return chunkLineRange(path, language, lines, 1, len(lines), maxLines, maxBytes)
+	}
+	return chunkStructuralRanges(path, language, lines, starts, maxLines, maxBytes)
+}
 
-	startLine := 1
-	lineNo := 0
-	linesInChunk := 0
+func splitChunkLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
 
-	flush := func(endLine int) {
-		txt := strings.TrimRight(b.String(), "\n")
-		if strings.TrimSpace(txt) == "" {
-			b.Reset()
-			linesInChunk = 0
-			startLine = endLine + 1
+func chunkStructuralRanges(path, language string, lines []string, starts []int, maxLines, maxBytes int) []Chunk {
+	starts = normalizedChunkStarts(starts, len(lines))
+	if len(starts) == 0 {
+		return chunkLineRange(path, language, lines, 1, len(lines), maxLines, maxBytes)
+	}
+	if starts[0] != 1 {
+		starts = append([]int{1}, starts...)
+	}
+
+	chunks := make([]Chunk, 0, len(starts))
+	currentStart, currentEnd := 0, 0
+	currentBytes := 0
+	flushCurrent := func() {
+		if currentStart == 0 {
 			return
 		}
-		chunks = append(chunks, Chunk{
-			Path:      path,
-			Language:  language,
-			StartLine: startLine,
-			EndLine:   endLine,
-			Content:   txt + "\n",
-		})
-		b.Reset()
-		linesInChunk = 0
-		startLine = endLine + 1
+		if chunk, ok := makeChunk(path, language, lines, currentStart, currentEnd); ok {
+			chunks = append(chunks, chunk)
+		}
+		currentStart, currentEnd, currentBytes = 0, 0, 0
 	}
 
-	for sc.Scan() {
-		lineNo++
-		line := sc.Text()
-		if b.Len()+len(line)+1 > maxBytes || linesInChunk >= maxLines {
-			flush(lineNo - 1)
+	for index, start := range starts {
+		end := len(lines)
+		if index+1 < len(starts) {
+			end = starts[index+1] - 1
 		}
-		b.WriteString(line)
-		b.WriteByte('\n')
-		linesInChunk++
+		unitLines := end - start + 1
+		unitBytes := chunkRangeBytes(lines, start, end)
+		if unitLines > maxLines || unitBytes > maxBytes {
+			flushCurrent()
+			chunks = append(chunks, chunkLineRange(path, language, lines, start, end, maxLines, maxBytes)...)
+			continue
+		}
+		if currentStart != 0 && (end-currentStart+1 > maxLines || currentBytes+unitBytes > maxBytes) {
+			flushCurrent()
+		}
+		if currentStart == 0 {
+			currentStart = start
+		}
+		currentEnd = end
+		currentBytes += unitBytes
 	}
-	if b.Len() > 0 {
-		flush(lineNo)
+	flushCurrent()
+	return chunks
+}
+
+func chunkLineRange(path, language string, lines []string, start, end, maxLines, maxBytes int) []Chunk {
+	chunks := []Chunk{}
+	chunkStart := start
+	bytes := 0
+	for line := start; line <= end; line++ {
+		lineBytes := len(lines[line-1]) + 1
+		if line > chunkStart && (line-chunkStart >= maxLines || bytes+lineBytes > maxBytes) {
+			if chunk, ok := makeChunk(path, language, lines, chunkStart, line-1); ok {
+				chunks = append(chunks, chunk)
+			}
+			chunkStart = line
+			bytes = 0
+		}
+		bytes += lineBytes
+	}
+	if chunk, ok := makeChunk(path, language, lines, chunkStart, end); ok {
+		chunks = append(chunks, chunk)
 	}
 	return chunks
+}
+
+func makeChunk(path, language string, lines []string, start, end int) (Chunk, bool) {
+	if start < 1 || end < start || end > len(lines) {
+		return Chunk{}, false
+	}
+	text := strings.TrimRight(strings.Join(lines[start-1:end], "\n")+"\n", "\n")
+	if strings.TrimSpace(text) == "" {
+		return Chunk{}, false
+	}
+	return Chunk{
+		Path:      path,
+		Language:  language,
+		StartLine: start,
+		EndLine:   end,
+		Content:   text + "\n",
+	}, true
+}
+
+func chunkRangeBytes(lines []string, start, end int) int {
+	total := 0
+	for line := start; line <= end; line++ {
+		total += len(lines[line-1]) + 1
+	}
+	return total
+}
+
+func normalizedChunkStarts(starts []int, lineCount int) []int {
+	seen := map[int]struct{}{}
+	out := make([]int, 0, len(starts))
+	for _, start := range starts {
+		if start < 1 || start > lineCount {
+			continue
+		}
+		if _, ok := seen[start]; ok {
+			continue
+		}
+		seen[start] = struct{}{}
+		out = append(out, start)
+	}
+	for index := 1; index < len(out); index++ {
+		if out[index] < out[index-1] {
+			// Parser and scanner outputs are normally ordered. Sorting this tiny
+			// slice keeps the range builder defensive without changing metadata.
+			for i := 0; i < len(out); i++ {
+				for j := i + 1; j < len(out); j++ {
+					if out[j] < out[i] {
+						out[i], out[j] = out[j], out[i]
+					}
+				}
+			}
+			break
+		}
+	}
+	return out
 }

--- a/internal/indexing/chunk_test.go
+++ b/internal/indexing/chunk_test.go
@@ -1,6 +1,10 @@
 package indexing
 
-import "testing"
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestChunkFile_GoFixtureAdjacentDeclsWithDocComments(t *testing.T) {
 	content := `package fixture
@@ -20,21 +24,261 @@ func AddTwo() int {
 		t.Fatalf("expected 3 chunks, got %d", len(chunks))
 	}
 
-	assertChunkBounds(t, chunks[0], 1, 4)
-	assertChunkBounds(t, chunks[1], 5, 8)
-	assertChunkBounds(t, chunks[2], 9, 10)
+	assertChunkBounds(t, chunks[0], 1, 2)
+	assertChunkBounds(t, chunks[1], 3, 6)
+	assertChunkBounds(t, chunks[2], 7, 10)
 
 	if chunks[0].Path != "fixture.go" || chunks[0].Language != "go" {
 		t.Fatalf("unexpected chunk metadata: path=%q language=%q", chunks[0].Path, chunks[0].Language)
 	}
-	if chunks[0].Content != "package fixture\n\n// AddOne returns a stable value.\nfunc AddOne() int {\n" {
+	if chunks[0].Content != "package fixture\n" {
 		t.Fatalf("unexpected first chunk content: %q", chunks[0].Content)
 	}
-	if chunks[1].Content != "\treturn 1\n}\n// AddTwo returns another stable value.\nfunc AddTwo() int {\n" {
+	if chunks[1].Content != "// AddOne returns a stable value.\nfunc AddOne() int {\n\treturn 1\n}\n" {
 		t.Fatalf("unexpected second chunk content: %q", chunks[1].Content)
 	}
-	if chunks[2].Content != "\treturn 2\n}\n" {
+	if chunks[2].Content != "// AddTwo returns another stable value.\nfunc AddTwo() int {\n\treturn 2\n}\n" {
 		t.Fatalf("unexpected third chunk content: %q", chunks[2].Content)
+	}
+}
+
+func TestChunkFile_GoGreedilyPacksWholeDeclarations(t *testing.T) {
+	content := `package fixture
+
+func One() {
+	println("one")
+}
+
+func Two() {
+	println("two")
+}
+`
+	chunks := ChunkFile("fixture.go", "go", content, 6, 1<<20)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %#v", chunks)
+	}
+	assertChunkBounds(t, chunks[0], 1, 6)
+	assertChunkBounds(t, chunks[1], 7, 9)
+}
+
+func TestChunkFile_GoOversizedDeclarationFallsBackLocally(t *testing.T) {
+	content := `package fixture
+
+func Large() {
+	println(1)
+	println(2)
+	println(3)
+	println(4)
+}
+func Small() {}
+`
+	chunks := ChunkFile("fixture.go", "go", content, 4, 1<<20)
+	want := [][2]int{{1, 2}, {3, 6}, {7, 8}, {9, 9}}
+	if len(chunks) != len(want) {
+		t.Fatalf("expected %d chunks, got %#v", len(want), chunks)
+	}
+	for index, bounds := range want {
+		assertChunkBounds(t, chunks[index], bounds[0], bounds[1])
+	}
+}
+
+func TestChunkFile_GoUsesPhysicalLinesWithLineDirectives(t *testing.T) {
+	content := "package fixture\n\n//line generated.go:1\nfunc One() {}\nfunc Two() {}\n"
+	chunks := ChunkFile("fixture.go", "go", content, 2, 1<<20)
+	want := [][2]int{{1, 2}, {3, 4}, {5, 5}}
+	if len(chunks) != len(want) {
+		t.Fatalf("expected physical declaration ranges, got %#v", chunks)
+	}
+	for index, bounds := range want {
+		assertChunkBounds(t, chunks[index], bounds[0], bounds[1])
+	}
+}
+
+func TestChunkFile_InvalidGoMatchesLineFallback(t *testing.T) {
+	content := "package fixture\nfunc Broken( {\nline 3\nline 4\nline 5\n"
+	got := ChunkFile("fixture.go", "go", content, 2, 1<<20)
+	want := ChunkFile("fixture.txt", "text", content, 2, 1<<20)
+	for index := range want {
+		want[index].Path = "fixture.go"
+		want[index].Language = "go"
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid Go did not preserve fallback:\ngot  %#v\nwant %#v", got, want)
+	}
+}
+
+func TestChunkFile_UsesOriginalSyntaxForRedactedGo(t *testing.T) {
+	original := `package fixture
+
+// Build returns a token.
+func Build() string {
+	token := jwt.New()
+	return token
+}
+func Next() {}
+`
+	redacted := strings.Replace(original, "jwt.New()", "[REDACTED]", 1)
+	chunks := chunkFileWithSyntaxSource("fixture.go", "go", redacted, original, 5, 1<<20)
+	if len(chunks) != 3 {
+		t.Fatalf("expected structural chunks from original syntax, got %#v", chunks)
+	}
+	assertChunkBounds(t, chunks[0], 1, 2)
+	assertChunkBounds(t, chunks[1], 3, 7)
+	assertChunkBounds(t, chunks[2], 8, 8)
+	if !strings.Contains(chunks[1].Content, "[REDACTED]") || strings.Contains(chunks[1].Content, "jwt.New()") {
+		t.Fatalf("chunk did not preserve redaction: %q", chunks[1].Content)
+	}
+}
+
+func TestChunkFile_JSAlignsTopLevelDeclarations(t *testing.T) {
+	content := `import { value } from "./value";
+
+/** First docs. */
+export function first() {
+	const nested = value;
+}
+// Worker docs.
+export class Worker {
+	run() {
+		return true;
+	}
+}
+export const arrow = () => {
+	return 1;
+};
+`
+	chunks := ChunkFile("fixture.ts", "ts/js", content, 6, 1<<20)
+	want := [][2]int{{1, 6}, {7, 12}, {13, 15}}
+	if len(chunks) != len(want) {
+		t.Fatalf("expected declaration-aligned chunks, got %#v", chunks)
+	}
+	for index, bounds := range want {
+		assertChunkBounds(t, chunks[index], bounds[0], bounds[1])
+	}
+	if !strings.HasPrefix(chunks[1].Content, "// Worker docs.") {
+		t.Fatalf("expected class documentation to stay attached: %q", chunks[1].Content)
+	}
+}
+
+func TestChunkFile_JSIgnoresNestedAndRegexBoundaries(t *testing.T) {
+	content := `export function outer() {
+	const nested = () => {
+		return "export class Fake {}";
+	};
+}
+const pattern = /[{}]/;
+export class Real {}
+`
+	chunks := ChunkFile("fixture.js", "ts/js", content, 5, 1<<20)
+	if len(chunks) != 2 {
+		t.Fatalf("expected nested declarations to remain inside outer chunk, got %#v", chunks)
+	}
+	assertChunkBounds(t, chunks[0], 1, 5)
+	assertChunkBounds(t, chunks[1], 6, 7)
+}
+
+func TestChunkFile_JSIgnoresDeclarationsInsideCommentsAndTemplates(t *testing.T) {
+	content := "/*\nexport class CommentFake {}\n*/\nconst template = `\nexport function TemplateFake() {}\n`;\nexport class Real {}\n"
+	chunks := ChunkFile("fixture.js", "ts/js", content, 3, 1<<20)
+	want := [][2]int{{1, 3}, {4, 6}, {7, 7}}
+	if len(chunks) != len(want) {
+		t.Fatalf("masked declarations created false boundaries: %#v", chunks)
+	}
+	for index, bounds := range want {
+		assertChunkBounds(t, chunks[index], bounds[0], bounds[1])
+	}
+}
+
+func TestChunkFile_JSKeepsModifiersDecoratorsAndDocumentationAttached(t *testing.T) {
+	content := `/** Worker docs. */
+@sealed({
+	enabled: true,
+})
+export default
+class Worker {}
+export const next = 1;
+`
+	lines := splitChunkLines(content)
+	starts, ok := jsChunkStarts([]byte(content), lines)
+	if !ok || !reflect.DeepEqual(starts, []int{1, 7}) {
+		t.Fatalf("declaration starts = %v, ok=%t, want [1 7]", starts, ok)
+	}
+	chunks := ChunkFile("fixture.ts", "ts/js", content, 6, 1<<20)
+	if len(chunks) != 2 {
+		t.Fatalf("expected decorated declaration and following export, got %#v", chunks)
+	}
+	assertChunkBounds(t, chunks[0], 1, 6)
+	assertChunkBounds(t, chunks[1], 7, 7)
+}
+
+func TestChunkFile_JSFoldsInterleavedPrefixes(t *testing.T) {
+	fixtures := []string{
+		"export default\n/** docs */\nclass Worker {}\nexport const next = 1;\n",
+		"@sealed\n/** docs */\nexport class Worker {}\nexport const next = 1;\n",
+	}
+	for _, content := range fixtures {
+		starts, ok := jsChunkStarts([]byte(content), splitChunkLines(content))
+		if !ok || !reflect.DeepEqual(starts, []int{1, 4}) {
+			t.Fatalf("interleaved prefix starts = %v, ok=%t for %q", starts, ok, content)
+		}
+	}
+}
+
+func TestChunkFile_JSTrailingBlockCommentDoesNotAbsorbPriorDeclaration(t *testing.T) {
+	content := `export function previous() {} /** docs
+ * for next
+ */
+export function next() {}
+`
+	starts, ok := jsChunkStarts([]byte(content), splitChunkLines(content))
+	if !ok || !reflect.DeepEqual(starts, []int{1, 4}) {
+		t.Fatalf("trailing block comment changed declaration starts = %v, ok=%t", starts, ok)
+	}
+}
+
+func TestChunkFile_JSHandlesRegexQuotesCommentsAndArrowReturns(t *testing.T) {
+	content := `const quotePattern = /['"]/;
+const markerPattern = /[/*]/;
+export const arrowPattern = () => /}/;
+export class Real {}
+`
+	starts, ok := jsChunkStarts([]byte(content), splitChunkLines(content))
+	if !ok || !reflect.DeepEqual(starts, []int{1, 2, 3, 4}) {
+		t.Fatalf("regex-bearing declaration starts = %v, ok=%t", starts, ok)
+	}
+}
+
+func TestChunkFile_JSXUsesLineFallback(t *testing.T) {
+	content := "export function First() {\n\treturn <div>don't split JSX</div>;\n}\nexport function Second() {}\n"
+	got := ChunkFile("fixture.tsx", "ts/js", content, 2, 1<<20)
+	want := ChunkFile("fixture.txt", "text", content, 2, 1<<20)
+	for index := range want {
+		want[index].Path = "fixture.tsx"
+		want[index].Language = "ts/js"
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TSX did not preserve line fallback:\ngot  %#v\nwant %#v", got, want)
+	}
+}
+
+func TestChunkFile_MalformedJSMatchesLineFallback(t *testing.T) {
+	content := "export function broken() {\nconst nested = 1;\nline 3\nline 4\n"
+	got := ChunkFile("fixture.ts", "ts/js", content, 2, 1<<20)
+	want := ChunkFile("fixture.txt", "text", content, 2, 1<<20)
+	for index := range want {
+		want[index].Path = "fixture.ts"
+		want[index].Language = "ts/js"
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("malformed JS did not preserve fallback:\ngot  %#v\nwant %#v", got, want)
+	}
+}
+
+func TestChunkFile_LongLineDoesNotDropFollowingContent(t *testing.T) {
+	long := strings.Repeat("x", 10_000)
+	chunks := ChunkFile("fixture.txt", "text", long+"\nafter\n", 10, 128)
+	if len(chunks) != 2 || chunks[0].Content != long+"\n" || chunks[1].Content != "after\n" {
+		t.Fatalf("long line content was lost: %#v", chunks)
 	}
 }
 

--- a/internal/indexing/indexer.go
+++ b/internal/indexing/indexer.go
@@ -121,7 +121,9 @@ func New(cfg Config) (*Indexer, error) {
 	}
 	idx.ignoreRules = rules
 
-	if err := idx.loadManifest(); err != nil || idx.manifest.RedactionFingerprint != idx.redactor.Fingerprint() {
+	if err := idx.loadManifest(); err != nil ||
+		idx.manifest.RedactionFingerprint != idx.redactor.Fingerprint() ||
+		idx.manifest.ChunkingFingerprint != idx.chunkingFingerprint() {
 		if err := idx.resetIndexFiles(); err != nil {
 			return nil, err
 		}
@@ -206,6 +208,8 @@ type DebugInfo struct {
 	SemanticEnabled  bool     `json:"semanticEnabled"`
 	EmbeddingModel   string   `json:"embeddingModel,omitempty"`
 	SemanticWeight   float64  `json:"semanticWeight,omitempty"`
+	ChunkingVersion  string   `json:"chunkingVersion"`
+	ChunkingIdentity string   `json:"chunkingFingerprint"`
 	VectorsIndexed   int      `json:"vectorsIndexed"`
 	LastError        string   `json:"lastError,omitempty"`
 }
@@ -238,6 +242,8 @@ func (i *Indexer) DebugInfo() DebugInfo {
 		ExtraIgnoreDirs:  append([]string{}, i.cfg.ExtraIgnoreDirs...),
 		ExtraIgnoreGlobs: append([]string{}, i.cfg.ExtraIgnoreGlobs...),
 		SemanticEnabled:  i.embedder != nil,
+		ChunkingVersion:  ChunkingVersion,
+		ChunkingIdentity: i.chunkingFingerprint(),
 		VectorsIndexed:   vectorsIndexed,
 		LastError:        i.status.Error,
 	}
@@ -742,8 +748,9 @@ func (i *Indexer) indexOne(ctx context.Context, abs, rel string, info os.FileInf
 	hash := hex.EncodeToString(sum[:16])
 
 	id := fileID(rel)
-	content := i.redactor.Redact(string(b))
-	chunks := ChunkFile(rel, guessLanguage(rel), content, i.cfg.MaxChunkLines, i.cfg.MaxChunkBytes)
+	syntaxSource := string(b)
+	content := i.redactor.Redact(syntaxSource)
+	chunks := chunkFileWithSyntaxSource(rel, guessLanguage(rel), content, syntaxSource, i.cfg.MaxChunkLines, i.cfg.MaxChunkBytes)
 	if err := i.writeChunksFile(id, chunks); err != nil {
 		return false, 0, err
 	}
@@ -922,6 +929,7 @@ func (i *Indexer) saveManifest() error {
 	i.manifest.Version = 1
 	i.manifest.Root = i.rootAbs
 	i.manifest.RedactionFingerprint = i.redactor.Fingerprint()
+	i.manifest.ChunkingFingerprint = i.chunkingFingerprint()
 	i.manifest.EmbeddingFingerprint = i.embeddingFingerprint()
 	i.manifest.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	b, err := json.MarshalIndent(i.manifest, "", "  ")
@@ -988,6 +996,7 @@ type manifest struct {
 	Root                 string               `json:"root"`
 	UpdatedAt            string               `json:"updatedAt"`
 	RedactionFingerprint string               `json:"redactionFingerprint"`
+	ChunkingFingerprint  string               `json:"chunkingFingerprint"`
 	EmbeddingFingerprint string               `json:"embeddingFingerprint"`
 	TotalBytes           int64                `json:"totalBytes"`
 	Files                map[string]fileEntry `json:"files"`
@@ -1008,6 +1017,7 @@ func (i *Indexer) resetIndexFiles() error {
 	}
 	i.manifest = manifest{
 		RedactionFingerprint: i.redactor.Fingerprint(),
+		ChunkingFingerprint:  i.chunkingFingerprint(),
 		EmbeddingFingerprint: i.embeddingFingerprint(),
 		Files:                map[string]fileEntry{},
 	}
@@ -1029,6 +1039,10 @@ func (i *Indexer) embeddingFingerprint() string {
 		return "disabled"
 	}
 	return i.embedder.Fingerprint()
+}
+
+func (i *Indexer) chunkingFingerprint() string {
+	return ChunkingFingerprint(i.cfg.MaxChunkLines, i.cfg.MaxChunkBytes)
 }
 
 func repoIndexDir(rootAbs string) (string, error) {
@@ -1141,10 +1155,10 @@ func applyDefaults(cfg *Config) {
 		cfg.MaxFileBytes = 1 * 1024 * 1024
 	}
 	if cfg.MaxChunkBytes <= 0 {
-		cfg.MaxChunkBytes = 8 * 1024
+		cfg.MaxChunkBytes = DefaultMaxChunkBytes
 	}
 	if cfg.MaxChunkLines <= 0 {
-		cfg.MaxChunkLines = 200
+		cfg.MaxChunkLines = DefaultMaxChunkLines
 	}
 	if math.IsNaN(cfg.SemanticWeight) || math.IsInf(cfg.SemanticWeight, 0) || cfg.SemanticWeight <= 0 || cfg.SemanticWeight > 1 {
 		cfg.SemanticWeight = embedding.DefaultSemanticWeight

--- a/internal/indexing/indexer_test.go
+++ b/internal/indexing/indexer_test.go
@@ -100,6 +100,60 @@ func TestIndexerRedactsPersistedChunksAndIgnoresEnvFiles(t *testing.T) {
 	}
 }
 
+func TestChunkingFingerprintChangeReindexesUnchangedFiles(t *testing.T) {
+	root := t.TempDir()
+	store := t.TempDir()
+	content := "package fixture\n\nfunc One() {\n\tprintln(1)\n}\nfunc Two() {}\n"
+	path := filepath.Join(root, "fixture.go")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := New(Config{RootAbs: root, StoreDir: store, MaxChunkLines: 2, MaxChunkBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstContext, firstCancel := context.WithCancel(context.Background())
+	first.Start(firstContext)
+	if err := first.IndexAll(firstContext); err != nil {
+		firstCancel()
+		t.Fatal(err)
+	}
+	firstCancel()
+	entry := first.manifest.Files["fixture.go"]
+	chunkPath := first.chunkFilePath(entry.ID)
+	if entry.Chunks < 2 {
+		t.Fatalf("expected small chunk limit to create multiple chunks, got %#v", entry)
+	}
+
+	second, err := New(Config{RootAbs: root, StoreDir: store, MaxChunkLines: 20, MaxChunkBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(chunkPath); !os.IsNotExist(err) {
+		t.Fatalf("expected changed chunking configuration to invalidate persisted chunks, got %v", err)
+	}
+	secondContext, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+	second.Start(secondContext)
+	if err := second.IndexAll(secondContext); err != nil {
+		t.Fatal(err)
+	}
+	chunks, err := second.FileChunks("fixture.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 1 || chunks[0].StartLine != 1 || chunks[0].EndLine != 6 {
+		t.Fatalf("expected unchanged file to be rebuilt with new chunking limits, got %#v", chunks)
+	}
+	if second.manifest.ChunkingFingerprint != second.chunkingFingerprint() {
+		t.Fatalf("manifest chunking fingerprint = %q, want %q", second.manifest.ChunkingFingerprint, second.chunkingFingerprint())
+	}
+	if second.DebugInfo().ChunkingIdentity != second.chunkingFingerprint() {
+		t.Fatalf("debug info omitted effective chunking identity: %#v", second.DebugInfo())
+	}
+}
+
 func TestIndexerPurgesChunksWhenRedactionConfigurationChanges(t *testing.T) {
 	root := t.TempDir()
 	store := t.TempDir()

--- a/internal/indexing/semantic_test.go
+++ b/internal/indexing/semantic_test.go
@@ -212,6 +212,69 @@ func TestEmbeddingFingerprintChangeReindexesUnchangedFiles(t *testing.T) {
 	}
 }
 
+func TestChunkingFingerprintChangeReembedsUnchangedFiles(t *testing.T) {
+	root := t.TempDir()
+	store := t.TempDir()
+	content := "package fixture\n\nfunc One() {\n\tprintln(1)\n}\nfunc Two() {}\n"
+	writeSemanticFixture(t, root, "fixture.go", content)
+	firstEmbedder := &testEmbedder{fingerprint: "stable-model"}
+	first, err := New(Config{
+		RootAbs:        root,
+		StoreDir:       store,
+		MaxChunkLines:  2,
+		MaxChunkBytes:  1 << 20,
+		MaxTotalBytes:  int64(len(content)),
+		Embedder:       firstEmbedder,
+		SemanticWeight: 0.65,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstContext, firstCancel := context.WithCancel(context.Background())
+	first.Start(firstContext)
+	if err := first.IndexAll(firstContext); err != nil {
+		firstCancel()
+		t.Fatal(err)
+	}
+	firstCancel()
+	entry := first.manifest.Files["fixture.go"]
+	vectorPath := first.vectorFilePath(entry.ID)
+	if _, err := os.Stat(vectorPath); err != nil {
+		t.Fatal(err)
+	}
+
+	secondEmbedder := &testEmbedder{fingerprint: "stable-model"}
+	second, err := New(Config{
+		RootAbs:        root,
+		StoreDir:       store,
+		MaxChunkLines:  20,
+		MaxChunkBytes:  1 << 20,
+		MaxTotalBytes:  int64(len(content)),
+		Embedder:       secondEmbedder,
+		SemanticWeight: 0.65,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(vectorPath); !os.IsNotExist(err) {
+		t.Fatalf("expected old vectors to be removed after chunking change, got %v", err)
+	}
+	secondContext, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+	second.Start(secondContext)
+	if err := second.IndexAll(secondContext); err != nil {
+		t.Fatal(err)
+	}
+	documentCalls, _ := secondEmbedder.calls()
+	if documentCalls == 0 {
+		t.Fatal("expected unchanged source to be re-embedded after chunking change")
+	}
+	rebuilt := second.manifest.Files["fixture.go"]
+	if rebuilt.Vectors == 0 || rebuilt.Vectors != rebuilt.Chunks {
+		t.Fatalf("expected vectors for every rebuilt chunk, got %#v", rebuilt)
+	}
+}
+
 func TestEmbeddingFailureFallsBackToLexicalSearch(t *testing.T) {
 	root := t.TempDir()
 	writeSemanticFixture(t, root, "auth.go", "package fixture\n// ExactNeedle remains searchable.\n")

--- a/internal/indexing/syntax_chunk.go
+++ b/internal/indexing/syntax_chunk.go
@@ -1,0 +1,338 @@
+package indexing
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var jsTopLevelDeclaration = regexp.MustCompile(`^[\t ]*(?:(?:export|default|declare|async|abstract)\s+)*(?:function\s*\*?\s+[A-Za-z_$]|class\s+[A-Za-z_$]|interface\s+[A-Za-z_$]|type\s+[A-Za-z_$]|enum\s+[A-Za-z_$]|namespace\s+[A-Za-z_$]|module\s+[A-Za-z_$]|(?:const|let|var)\s+[A-Za-z_$])`)
+var jsTopLevelExport = regexp.MustCompile(`^[\t ]*export\b`)
+var jsModifierOnly = regexp.MustCompile(`^[\t ]*(?:export(?:\s+default)?|default|declare|abstract|async)[\t ]*;?[\t ]*$`)
+
+func syntaxChunkStarts(path, language, source string, lines []string) ([]int, bool) {
+	switch chunkLanguage(path, language) {
+	case "go":
+		return goChunkStarts(path, source)
+	case "javascript":
+		return jsChunkStarts([]byte(source), lines)
+	default:
+		return nil, false
+	}
+}
+
+func chunkLanguage(path, language string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jsx", ".tsx":
+		// JSX text needs a tag-aware lexer. Preserve the exact line fallback
+		// until that grammar can be handled without false string/comment states.
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(language)) {
+	case "go", "golang":
+		return "go"
+	case "ts/js", "javascript", "typescript", "js", "ts":
+		return "javascript"
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".go":
+		return "go"
+	case ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts":
+		return "javascript"
+	default:
+		return ""
+	}
+}
+
+func goChunkStarts(path, source string) ([]int, bool) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil || file == nil || len(file.Decls) == 0 {
+		return nil, false
+	}
+	starts := make([]int, 0, len(file.Decls))
+	for _, declaration := range file.Decls {
+		position := declaration.Pos()
+		switch typed := declaration.(type) {
+		case *ast.FuncDecl:
+			if typed.Doc != nil {
+				position = typed.Doc.Pos()
+			}
+		case *ast.GenDecl:
+			if typed.Doc != nil {
+				position = typed.Doc.Pos()
+			}
+		}
+		starts = append(starts, fset.PositionFor(position, false).Line)
+	}
+	return starts, true
+}
+
+func jsChunkStarts(source []byte, lines []string) ([]int, bool) {
+	masked, ok := maskJSChunkSource(source)
+	if !ok {
+		return nil, false
+	}
+	topLevel, ok := jsTopLevelLayout(masked, len(lines))
+	if !ok {
+		return nil, false
+	}
+	maskedLines := splitChunkLines(string(masked))
+	if len(maskedLines) != len(lines) {
+		return nil, false
+	}
+	starts := []int{}
+	for index, line := range maskedLines {
+		if index >= len(topLevel) || !topLevel[index] {
+			continue
+		}
+		if !jsTopLevelDeclaration.MatchString(line) && !jsTopLevelExport.MatchString(line) {
+			continue
+		}
+		starts = append(starts, leadingJSChunkBoundary(lines, maskedLines, topLevel, index+1))
+	}
+	if len(starts) == 0 {
+		return nil, false
+	}
+	return normalizedChunkStarts(starts, len(lines)), true
+}
+
+func maskJSChunkSource(source []byte) ([]byte, bool) {
+	masked := append([]byte(nil), source...)
+	inLineComment := false
+	inBlockComment := false
+	inRegex := false
+	inRegexClass := false
+	var quote byte
+	escaped := false
+	for index := 0; index < len(source); index++ {
+		current := source[index]
+		if inLineComment {
+			if current == '\n' {
+				inLineComment = false
+				masked[index] = '\n'
+			} else {
+				masked[index] = ' '
+			}
+			continue
+		}
+		if inBlockComment {
+			if current == '\n' {
+				masked[index] = '\n'
+			} else {
+				masked[index] = ' '
+			}
+			if current == '*' && index+1 < len(source) && source[index+1] == '/' {
+				masked[index+1] = ' '
+				index++
+				inBlockComment = false
+			}
+			continue
+		}
+		if inRegex {
+			if current == '\n' {
+				return nil, false
+			}
+			masked[index] = ' '
+			if escaped {
+				escaped = false
+				continue
+			}
+			if current == '\\' {
+				escaped = true
+				continue
+			}
+			if current == '[' {
+				inRegexClass = true
+				continue
+			}
+			if current == ']' {
+				inRegexClass = false
+				continue
+			}
+			if current == '/' && !inRegexClass {
+				inRegex = false
+				for index+1 < len(source) && isASCIIAlpha(source[index+1]) {
+					index++
+					masked[index] = ' '
+				}
+			}
+			continue
+		}
+		if quote != 0 {
+			if current == '\n' {
+				masked[index] = '\n'
+			} else {
+				masked[index] = ' '
+			}
+			if escaped {
+				escaped = false
+				continue
+			}
+			if current == '\\' {
+				escaped = true
+				continue
+			}
+			if current == quote {
+				quote = 0
+			}
+			continue
+		}
+		if current == '/' && index+1 < len(source) && source[index+1] == '/' {
+			masked[index], masked[index+1] = ' ', ' '
+			index++
+			inLineComment = true
+			continue
+		}
+		if current == '/' && index+1 < len(source) && source[index+1] == '*' {
+			masked[index], masked[index+1] = ' ', ' '
+			index++
+			inBlockComment = true
+			continue
+		}
+		if current == '/' && jsChunkRegexCanStart(masked, index) {
+			masked[index] = ' '
+			inRegex = true
+			inRegexClass = false
+			escaped = false
+			continue
+		}
+		if current == '\'' || current == '"' || current == '`' {
+			quote = current
+			masked[index] = ' '
+		}
+	}
+	if inBlockComment || inRegex || quote != 0 {
+		return nil, false
+	}
+	return masked, true
+}
+
+func jsTopLevelLayout(masked []byte, lineCount int) ([]bool, bool) {
+	topLevel := make([]bool, lineCount)
+	if lineCount > 0 {
+		topLevel[0] = true
+	}
+	braceDepth, parenDepth, bracketDepth := 0, 0, 0
+	line := 0
+	for _, current := range masked {
+		switch current {
+		case '{':
+			braceDepth++
+		case '}':
+			braceDepth--
+		case '(':
+			parenDepth++
+		case ')':
+			parenDepth--
+		case '[':
+			bracketDepth++
+		case ']':
+			bracketDepth--
+		case '\n':
+			line++
+			if line < len(topLevel) {
+				topLevel[line] = braceDepth == 0 && parenDepth == 0 && bracketDepth == 0
+			}
+		}
+		if braceDepth < 0 || parenDepth < 0 || bracketDepth < 0 {
+			return nil, false
+		}
+	}
+	if braceDepth != 0 || parenDepth != 0 || bracketDepth != 0 {
+		return nil, false
+	}
+	return topLevel, true
+}
+
+func leadingJSChunkBoundary(lines, maskedLines []string, topLevel []bool, declarationLine int) int {
+	boundary := declarationLine - 1
+	for {
+		previous := boundary
+		for boundary > 0 && jsModifierOnly.MatchString(maskedLines[boundary-1]) {
+			boundary--
+		}
+		for {
+			index := boundary - 1
+			for index >= 0 && !topLevel[index] {
+				index--
+			}
+			if index < 0 || !strings.HasPrefix(strings.TrimSpace(maskedLines[index]), "@") {
+				break
+			}
+			boundary = index
+		}
+		boundary = leadingJSCommentBoundary(lines, boundary)
+		if boundary == previous {
+			return boundary + 1
+		}
+	}
+}
+
+func leadingJSCommentBoundary(lines []string, boundary int) int {
+	index := boundary - 1
+	if index < 0 || strings.TrimSpace(lines[index]) == "" {
+		return boundary
+	}
+	trimmed := strings.TrimSpace(lines[index])
+	if strings.HasPrefix(trimmed, "//") {
+		for index >= 0 && strings.HasPrefix(strings.TrimSpace(lines[index]), "//") {
+			index--
+		}
+		return index + 1
+	}
+	if !strings.HasSuffix(trimmed, "*/") {
+		return boundary
+	}
+	for index >= 0 {
+		line := strings.TrimSpace(lines[index])
+		if opener := strings.Index(lines[index], "/*"); opener >= 0 {
+			if strings.TrimSpace(lines[index][:opener]) == "" {
+				return index
+			}
+			break
+		}
+		if line == "" {
+			break
+		}
+		index--
+	}
+	return boundary
+}
+
+func jsChunkRegexCanStart(masked []byte, slash int) bool {
+	previous := slash - 1
+	for previous >= 0 && (masked[previous] == ' ' || masked[previous] == '\t' || masked[previous] == '\r' || masked[previous] == '\n') {
+		previous--
+	}
+	if previous < 0 || strings.ContainsRune("=(:,[!&|?;{}", rune(masked[previous])) {
+		return true
+	}
+	if masked[previous] == '>' {
+		before := previous - 1
+		for before >= 0 && (masked[before] == ' ' || masked[before] == '\t') {
+			before--
+		}
+		if before >= 0 && masked[before] == '=' {
+			return true
+		}
+	}
+	if isASCIIAlpha(masked[previous]) {
+		start := previous
+		for start > 0 && isASCIIAlpha(masked[start-1]) {
+			start--
+		}
+		switch string(masked[start : previous+1]) {
+		case "await", "case", "delete", "in", "instanceof", "of", "return", "throw", "typeof", "void", "yield":
+			return true
+		}
+	}
+	return false
+}
+
+func isASCIIAlpha(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}


### PR DESCRIPTION
## Summary

- align Go chunks to AST declarations, including associated documentation comments
- add conservative syntax-aware chunking for JavaScript and TypeScript while keeping JSX/TSX on the existing line fallback
- preserve lossless source coverage and split only oversized structural units
- fingerprint chunking behavior so stale indexes are rebuilt and semantic vectors are re-embedded
- refresh retrieval fixtures, baseline, and documentation for the new boundaries

## Why

Fixed line/byte chunking could split declarations and detach documentation from the code it describes. That reduced the context quality of both lexical results and embeddings. Existing manifests also needed a reliable way to detect boundary-policy changes.

## Impact

- existing indexes rebuild once when the chunking fingerprint changes
- semantic indexes re-embed rebuilt chunks
- custom chunk limits participate in evaluation fingerprints
- JSX and TSX intentionally retain line-based chunking until a safe structural parser is added

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- retrieval evaluation matched the checked-in baseline exactly
- `make evaluation-ci EVALUATION_OUT=/tmp/memento-evaluation-syntax-final2` passed the enforced retrieval baseline; the pre-existing advisory recall target of 0.95 remains advisory
- `git diff --check`

Retrieval metrics: precision@5 0.45, recall@5 0.875, MRR 1.0, nDCG 0.879793.