### PR TITLE
feat: add explicit diff context tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ChatGPT on the web does not load local Codex configuration or launch local STDIO
 
 ## What It Does
 
-- Exposes MCP tools for repo operations: `repo_list_files`, `repo_read_file`, `repo_search`, `repo_related_files`, `repo_context`, `repo_switch_workspace`
+- Exposes MCP tools for repo operations: `repo_list_files`, `repo_read_file`, `repo_search`, `repo_related_files`, `repo_context`, `repo_diff_context`, `repo_switch_workspace`
 - Maintains an on-disk code index per repository for fast, bounded context retrieval
 - Stores explicit repo-scoped notes: `memory_upsert`, `memory_search`, `memory_clear`
 - Can record strictly aggregate, local-only helpfulness feedback after explicit opt-in
@@ -246,5 +246,6 @@ Treat Memento as the default for both memory and context in a repository:
 
 - **Prefer Memento memory over any other memory store.** Persist durable decisions and handoffs with `memory_upsert` (anchored to code); recall with `memory_search` / `memory_list` before re-deriving. `memory_gc` / `memory_delete` / `memory_clear` are destructive — only on explicit instruction.
 - **Prime the codebase index for leaner context and lower tokens.** Lead with `repo_context` on the active file, `repo_outline` for signatures, `repo_search` for symbols, and `repo_related_files` for imports — reach for `repo_read_file` only for the exact path you need. Querying the index first (and reading whole files last) is the main lever for lower token usage.
+- **Center reviews on known changed files.** Use `repo_diff_context` with explicit repo-relative paths to get bounded chunks and an inclusion/omission summary without expanding into the relationship graph.
 
 To make this automatic in a project, run `memento-mcp claude-md` in its root: it writes this section into `./CLAUDE.local.md` so the guidance loads every session. Rerun it to update the block in place; use `--print-only` to preview.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -123,7 +123,7 @@ No macOS ou WSL, `claude mcp add-from-claude-desktop` pode importar esse servido
 
 ## O Que Faz
 
-- Expõe ferramentas MCP para operações no repositório: `repo_list_files`, `repo_read_file`, `repo_search`, `repo_related_files`, `repo_context`, `repo_switch_workspace`
+- Expõe ferramentas MCP para operações no repositório: `repo_list_files`, `repo_read_file`, `repo_search`, `repo_related_files`, `repo_context`, `repo_diff_context`, `repo_switch_workspace`
 - Mantém um índice de código em disco por repositório para recuperação de contexto rápida e com limites definidos
 - Armazena notas explícitas com escopo do repositório: `memory_upsert`, `memory_search`, `memory_clear`
 - Suporta uma extensão complementar para VS Code que instala e configura o servidor
@@ -205,5 +205,6 @@ Trate o Memento como o padrão tanto para memória quanto para contexto em um re
 
 - **Prefira a memória do Memento a qualquer outro armazenamento de memória.** Persista decisões duráveis e handoffs com `memory_upsert` (ancorado ao código); recupere com `memory_search` / `memory_list` antes de re-derivar. `memory_gc` / `memory_delete` / `memory_clear` são destrutivos — use apenas com instrução explícita.
 - **Prepare o índice do repositório para um contexto mais enxuto e menos tokens.** Comece com `repo_context` no arquivo ativo, `repo_outline` para assinaturas, `repo_search` para símbolos e `repo_related_files` para imports — recorra a `repo_read_file` apenas para o caminho exato de que você precisa. Consultar o índice primeiro (e ler arquivos completos por último) é a principal forma de reduzir o uso de tokens.
+- **Centralize revisões nos arquivos alterados conhecidos.** Use `repo_diff_context` com caminhos explícitos relativos ao repositório para obter chunks limitados e um resumo de inclusão/omissão sem expandir o grafo de relacionamentos.
 
 Para tornar isso automático em um projeto, execute `memento-mcp claude-md` na raiz dele: o comando grava esta seção em `./CLAUDE.local.md` para que a orientação seja carregada em toda sessão. Rode novamente para atualizar o bloco no lugar; use `--print-only` para pré-visualizar.

--- a/TODO.md
+++ b/TODO.md
@@ -83,7 +83,7 @@ Implemented in `internal/indexing/chunk.go` and `internal/indexing/syntax_chunk.
 
 ### Slice 14A — `repo_diff_context` MVP (explicit paths)
 
-- Status: todo
+- Status: done
 - Owner: @caiowilson
 - Difficulty: medium
 - Scope: `internal/mcp/` (new tool)
@@ -95,10 +95,12 @@ Edit/review workflows need context centered on changed files, not full graph con
 
 #### Steps
 
-- [ ] Add `repo_diff_context` tool that accepts explicit repo-relative paths (status: todo)
-- [ ] Return only chunks overlapping those paths with compact nearby context (status: todo)
-- [ ] Include a concise summary block in the response (status: todo)
-- [ ] Add tests for explicit-path behavior (status: todo)
+- [x] Add `repo_diff_context` tool that accepts explicit repo-relative paths (status: done)
+- [x] Return only chunks overlapping those paths with compact nearby context (status: done)
+- [x] Include a concise summary block in the response (status: done)
+- [x] Add tests for explicit-path behavior (status: done)
+
+Implemented in `internal/mcp/diff_context_tool.go` with ordered path normalization, exact-file-only chunk selection, token/byte and per-file limits, skipped/omitted accounting, and explicit-path regression coverage.
 
 ### Slice 14B — `repo_diff_context` dirty-worktree auto-detection
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This directory collects the main project documentation, including client setup, 
 - `repo_related_files` — related files for a given path (Go/TS/JS/PHP-aware; PHP resolves Composer PSR-4 imports, symbol references, and common Laravel view/config conventions)
 - `repo_outline` — compact structured signatures, documentation, imports, and line ranges for one file
 - `repo_context` — indexed chunks for a file + related files, with intent-aware routing for `navigate`, `implement`, and `review`
+- `repo_diff_context` — compact indexed chunks from only an explicit ordered list of changed repo-relative paths, plus inclusion/omission counts
 - `repo_switch_workspace` — switch active workspace root at runtime without restarting MCP
 - `repo_index_status` — background indexer status
 - `repo_reindex` — trigger full re-index
@@ -132,6 +133,7 @@ Example anchored upsert:
 
 - Use `repo_outline` when you need a file's structure before deciding which source ranges to read.
 - Prefer `repo_context` with `intent` for normal workflows.
+- Use `repo_diff_context` when changed paths are already known and related-file expansion would add noise. Slice 14A requires explicit `paths`; automatic dirty-worktree detection and unified diff summaries belong to Slice 14B.
 - Use `intent: "navigate"` for lighter outlines and `intent: "implement"` or `intent: "review"` for mixed full+outline context.
 - Omit `mode` unless you need to force `full`, `outline`, or `summary`.
 - Existing callers that already send `mode` are unchanged.
@@ -158,12 +160,13 @@ Cross-file edges intentionally remain in `repo_related_files`; use that tool to 
 Defaults are sized to stay below Claude Code's roughly 10k-token MCP result warning in normal use:
 
 - `repo_context` defaults to `maxTokens: 7000`, using a conservative `ceil(UTF-8 bytes / 4)` estimate, with `maxTotalBytes: 32000` retained as a hard ceiling.
+- `repo_diff_context` defaults to three chunks per file, `maxTokens: 4000`, `maxTotalBytes: 16000`, and at most 20 explicit paths. It reports indexed, included, skipped, and omitted counts instead of silently expanding scope.
 - `repo_read_file` defaults to `maxBytes: 32000`.
 - `repo_search` caps each returned snippet to `maxSnippetBytes: 500`.
 
 Set `MEMENTO_CONTEXT_MAX_TOKENS` to change the server default, or pass `maxTokens` on an individual `repo_context` call. The token budget is the primary packing constraint; full-mode candidates are ordered by weighted relevance per estimated token, and an oversized chunk is skipped so smaller later candidates can still fit. Callers can still change the hard byte ceiling with `maxTotalBytes`.
 
-The `repo_context`, `repo_read_file`, and `repo_search` tool definitions advertise `_meta["anthropic/maxResultSizeChars"] = 500000` so Claude Code can handle intentional large reads without its smaller default persistence threshold surprising the caller. Client-side settings such as `MAX_MCP_OUTPUT_TOKENS` may still impose a stricter display/context budget; lower the tool arguments when you want compact responses, or raise the client setting when you intentionally need larger results.
+The `repo_context`, `repo_diff_context`, `repo_read_file`, and `repo_search` tool definitions advertise `_meta["anthropic/maxResultSizeChars"] = 500000` so Claude Code can handle intentional large reads without its smaller default persistence threshold surprising the caller. Client-side settings such as `MAX_MCP_OUTPUT_TOKENS` may still impose a stricter display/context budget; lower the tool arguments when you want compact responses, or raise the client setting when you intentionally need larger results.
 
 Run `go test ./internal/mcp -run '^$' -bench BenchmarkContextPacking -benchmem` to compare the previous byte-only accounting baseline with token-primary packing overhead.
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -181,6 +181,7 @@ Use the output of `print-guidance` directly, or paste the following into client 
 
 ```text
 When using memento-mcp, start with repo_context and set intent to navigate, implement, or review.
+Use repo_diff_context when changed repo-relative paths are already known and you want compact context from only those files.
 Use repo_outline when you need signatures and file structure without implementation bodies.
 Anchor durable notes to code when possible. Treat stale notes as evidence to verify, then call memory_verify or memory_tombstone after adjudication.
 Omit mode unless you need to force a low-level output such as full, outline, or summary.
@@ -191,13 +192,14 @@ Existing explicit mode calls still work, but new callers should prefer intent.
 
 ## Claude Code output limits
 
-`repo_context`, `repo_read_file`, and `repo_search` default to compact responses to avoid Claude Code's MCP result warning near 10k tokens:
+`repo_context`, `repo_diff_context`, `repo_read_file`, and `repo_search` default to compact responses to avoid Claude Code's MCP result warning near 10k tokens:
 
 - `repo_context`: `maxTokens` defaults to `7000` using an approximate `ceil(UTF-8 bytes / 4)` estimator; `maxTotalBytes` remains a `32000` hard ceiling.
+- `repo_diff_context`: at most 20 explicit paths, three chunks per file, `maxTokens: 4000`, and `maxTotalBytes: 16000` by default.
 - `repo_read_file`: `maxBytes` defaults to `32000`.
 - `repo_search`: each snippet is capped by `maxSnippetBytes`, default `500`.
 
-The same three tools advertise `_meta["anthropic/maxResultSizeChars"] = 500000` for intentional large reads. Claude Code's own `MAX_MCP_OUTPUT_TOKENS` setting can still be lower than the server-side caps, so tune the tool arguments and the client setting together when you need larger context.
+The same four tools advertise `_meta["anthropic/maxResultSizeChars"] = 500000` for intentional large reads. Claude Code's own `MAX_MCP_OUTPUT_TOKENS` setting can still be lower than the server-side caps, so tune the tool arguments and the client setting together when you need larger context.
 
 Set `MEMENTO_CONTEXT_MAX_TOKENS` to change the default token budget, or pass `maxTokens` to one `repo_context` call. Responses report `usedTokens`, `usedBytes`, and the estimator name under `limits`.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -103,6 +103,8 @@ Baseline refresh rationale for issue #30: the new feedback documentation moved t
 
 Baseline refresh rationale for syntax-aware chunking: the chunk construction algorithm now prefers complete Go and JavaScript/TypeScript declarations, so the retrieval configuration fingerprint includes its version. The `ReloadIgnoreRules` judgments were moved to the current declaration and exact reference comment; the previous second judgment pointed at a nearby line that only overlapped under fixed-size chunking. The committed lexical baseline was regenerated against those intentional boundary and judgment changes; this is a retrieval-behavior change, not an anchor-only refresh.
 
+Baseline refresh rationale for Slice 14A: adding `repo_diff_context`, bounded-output constants, and indexer lifecycle safeguards moved several exact fixture targets without changing the chunking or retrieval-scoring algorithms. All judgments were re-audited to the current declarations, references, and output-budget passages before regenerating the lexical baseline; metric changes here reflect corrected anchor drift and the newly indexed source layout.
+
 ## Validate the contract
 
 ```bash

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -78,6 +78,7 @@ printf '%s\n' \
 - `repo_related_files` to fetch “nearby” context for a file (same folder + Go/TS/JS/PHP import/semantic analysis).
 - `repo_outline` to inspect symbols, signatures, documentation, and line ranges without function bodies.
 - `repo_context` to fetch a single “context window” with intent-aware routing (uses automatic indexing in the background).
+- `repo_diff_context` to fetch compact indexed chunks from only an explicit list of changed repo-relative paths.
 - `repo_switch_workspace` to retarget the server to another repository/workspace root at runtime (no process restart).
 - Repo-scoped explicit memory (`memory_*`) persisted under `~/.memento-mcp/`.
 - Optional code anchors that flag stale notes, preserve them for verification, and protect renamed or branch-specific referents from accidental eviction.

--- a/evaluation/baselines/retrieval-ci-v1.json
+++ b/evaluation/baselines/retrieval-ci-v1.json
@@ -2,13 +2,13 @@
   "version": 1,
   "mode": "lexical",
   "configurationFingerprint": "sha256:099fffde0a60d5ac1ab755c8e6c73262a181de6f00fca1c0807efea2dbb526b9",
-  "fixtureFingerprint": "sha256:60e2f8eb07e8a85f61eb86a15891bd2be125d854236a658a7a0caa834e0f46ca",
+  "fixtureFingerprint": "sha256:f2325f18344164699fc02405dc8ba5fb2add1ee466d952389a346174ef90bfc6",
   "queryCount": 4,
   "k": 5,
   "metrics": {
-    "precision": 0.45,
-    "recall": 0.875,
+    "precision": 0.5,
+    "recall": 1,
     "mrr": 1,
-    "ndcg": 0.8797931570750352
+    "ndcg": 0.9765063588836707
   }
 }

--- a/evaluation/fixtures/retrieval.json
+++ b/evaluation/fixtures/retrieval.json
@@ -6,8 +6,8 @@
       "id": "ignore-rule-reload",
       "query": "ReloadIgnoreRules",
       "relevant": [
-        { "path": "internal/indexing/indexer.go", "startLine": 138, "endLine": 139 },
-        { "path": "internal/indexing/indexer.go", "startLine": 650, "endLine": 650 },
+        { "path": "internal/indexing/indexer.go", "startLine": 147, "endLine": 148 },
+        { "path": "internal/indexing/indexer.go", "startLine": 728, "endLine": 728 },
         { "path": "internal/indexing/fs_change.go", "startLine": 142, "endLine": 142 }
       ]
     },
@@ -15,25 +15,25 @@
       "id": "match-centered-truncation",
       "query": "truncateStringAroundBytes",
       "relevant": [
-        { "path": "internal/mcp/output_limits.go", "startLine": 34, "endLine": 34 },
+        { "path": "internal/mcp/output_limits.go", "startLine": 38, "endLine": 38 },
         { "path": "internal/mcp/output_limits_test.go", "startLine": 35, "endLine": 35 },
-        { "path": "internal/mcp/repo_tools.go", "startLine": 405, "endLine": 405 }
+        { "path": "internal/mcp/repo_tools.go", "startLine": 415, "endLine": 415 }
       ]
     },
     {
       "id": "anthropic-result-limit",
       "query": "defaultAnthropicMaxResultSizeChars",
       "relevant": [
-        { "path": "internal/mcp/output_limits.go", "startLine": 4, "endLine": 16 },
-        { "path": "internal/mcp/server_test.go", "startLine": 64, "endLine": 64 }
+        { "path": "internal/mcp/output_limits.go", "startLine": 4, "endLine": 4 },
+        { "path": "internal/mcp/server_test.go", "startLine": 65, "endLine": 65 }
       ]
     },
     {
       "id": "client-output-budget",
       "query": "MAX_MCP_OUTPUT_TOKENS",
       "relevant": [
-        { "path": "docs/README.md", "startLine": 162, "endLine": 162 },
-        { "path": "docs/clients.md", "startLine": 181, "endLine": 181 }
+        { "path": "docs/README.md", "startLine": 169, "endLine": 169 },
+        { "path": "docs/clients.md", "startLine": 202, "endLine": 202 }
       ]
     }
   ]

--- a/internal/app/claudemd.go
+++ b/internal/app/claudemd.go
@@ -60,6 +60,7 @@ const recommendedWorkflowBlock = claudeMDMarkerStart + "\n" +
 	"\n" +
 	"- **Prefer Memento memory over any other memory store.** Persist durable decisions and handoffs with `memory_upsert` (anchored to code); recall with `memory_search` / `memory_list` before re-deriving. `memory_gc` / `memory_delete` / `memory_clear` are destructive — only on explicit instruction.\n" +
 	"- **Prime the codebase index for leaner context and lower tokens.** Lead with `repo_context` on the active file, `repo_outline` for signatures, `repo_search` for symbols, and `repo_related_files` for imports — reach for `repo_read_file` only for the exact path you need. Querying the index first (and reading whole files last) is the main lever for lower token usage.\n" +
+	"- **Center reviews on known changed files.** Use `repo_diff_context` with explicit repo-relative paths to get bounded chunks and an inclusion/omission summary without expanding into the relationship graph.\n" +
 	claudeMDMarkerEnd + "\n"
 
 // runClaudeMD is the entry point for `memento-mcp claude-md`. It upserts the

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -101,6 +101,7 @@ func buildMCPServersConfigJSON(command string) (string, error) {
 
 func clientGuidanceText() string {
 	return `When using memento-mcp, start with repo_context and set intent to navigate, implement, or review.
+Use repo_diff_context when changed repo-relative paths are already known and you want compact context from only those files.
 Use repo_outline when you need signatures and file structure without implementation bodies.
 Anchor durable notes to code when possible. Verify stale notes before refreshing or tombstoning them.
 Use the prime MCP prompt at session start and explicit note/file resources when the client supports native prompts and @-mentions.

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -62,7 +62,7 @@ func TestHandleCLICommandPrintGuidance(t *testing.T) {
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "repo_context") || !strings.Contains(stdout.String(), "repo_outline") || !strings.Contains(stdout.String(), "Anchor durable notes") || !strings.Contains(stdout.String(), "prime MCP prompt") || !strings.Contains(stdout.String(), "intent") {
+	if !strings.Contains(stdout.String(), "repo_context") || !strings.Contains(stdout.String(), "repo_diff_context") || !strings.Contains(stdout.String(), "repo_outline") || !strings.Contains(stdout.String(), "Anchor durable notes") || !strings.Contains(stdout.String(), "prime MCP prompt") || !strings.Contains(stdout.String(), "intent") {
 		t.Fatalf("expected repo_context guidance, got %q", stdout.String())
 	}
 }

--- a/internal/indexing/git_change.go
+++ b/internal/indexing/git_change.go
@@ -104,11 +104,23 @@ func (m *GitChangeMonitor) flush() {
 	}
 	m.mu.Unlock()
 
-	if len(del) > 0 {
-		_ = m.idx.RemovePaths(del)
+	ignoreFileChanged := false
+	for _, changed := range append(add, del...) {
+		base := filepath.Base(changed)
+		if base == ".gitignore" || base == ".mementoignore" {
+			ignoreFileChanged = true
+			break
+		}
 	}
-	if len(add) > 0 {
-		_ = m.idx.EnsureIndexed(context.Background(), add)
+	if ignoreFileChanged {
+		_ = m.idx.IndexAll(context.Background())
+	} else {
+		if len(del) > 0 {
+			_ = m.idx.RemovePaths(del)
+		}
+		if len(add) > 0 {
+			_ = m.idx.EnsureIndexed(context.Background(), add)
+		}
 	}
 	if m.onChange != nil {
 		m.onChange(add, del)

--- a/internal/indexing/git_change_test.go
+++ b/internal/indexing/git_change_test.go
@@ -1,6 +1,11 @@
 package indexing
 
 import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -32,5 +37,40 @@ func TestParsePorcelainZ(t *testing.T) {
 	}
 	if len(expectDel) != 0 {
 		t.Fatalf("missing delete paths: %#v", expectDel)
+	}
+}
+
+func TestGitChangeMonitorReindexesWhenIgnoreFileChanges(t *testing.T) {
+	root := t.TempDir()
+	if output, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secret.go"), []byte("package secret\n\nconst SecretNeedle = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := New(Config{RootAbs: root, StoreDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	idx.Start(ctx)
+	if err := idx.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.FileChunks("secret.go"); err != nil {
+		t.Fatalf("expected initial chunks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("secret.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	monitor := NewGitChangeMonitor(root, idx, 0, 0, nil)
+	monitor.pendingAdd[".gitignore"] = struct{}{}
+	monitor.flush()
+	if _, err := idx.FileChunks("secret.go"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Git ignore change left stale chunks: %v", err)
 	}
 }

--- a/internal/indexing/indexer.go
+++ b/internal/indexing/indexer.go
@@ -62,7 +62,10 @@ type Indexer struct {
 	status                Status
 	embeddingBackoffUntil time.Time
 
-	reqCh chan request
+	reqCh         chan request
+	startOnce     sync.Once
+	workerStarted chan struct{}
+	workerDone    chan struct{}
 }
 
 type request struct {
@@ -72,7 +75,11 @@ type request struct {
 	done  chan error
 }
 
-var errEmbeddingBackoff = errors.New("embedding runtime is in retry backoff")
+var (
+	errEmbeddingBackoff  = errors.New("embedding runtime is in retry backoff")
+	errIndexerNotStarted = errors.New("indexer has not been started")
+	errIndexerStopped    = errors.New("indexer has stopped")
+)
 
 func New(cfg Config) (*Indexer, error) {
 	if cfg.RootAbs == "" {
@@ -107,12 +114,14 @@ func New(cfg Config) (*Indexer, error) {
 	}
 
 	idx := &Indexer{
-		rootAbs:  rootAbs,
-		dir:      dir,
-		cfg:      cfg,
-		redactor: cfg.Redactor,
-		embedder: cfg.Embedder,
-		reqCh:    make(chan request, 8),
+		rootAbs:       rootAbs,
+		dir:           dir,
+		cfg:           cfg,
+		redactor:      cfg.Redactor,
+		embedder:      cfg.Embedder,
+		reqCh:         make(chan request, 8),
+		workerStarted: make(chan struct{}),
+		workerDone:    make(chan struct{}),
 	}
 
 	rules, err := loadIgnoreRules(rootAbs)
@@ -148,25 +157,67 @@ func (i *Indexer) ReloadIgnoreRules() error {
 }
 
 func (i *Indexer) Start(ctx context.Context) {
-	go i.worker(ctx)
-	if i.cfg.PollInterval > 0 {
-		go i.poller(ctx)
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	i.startOnce.Do(func() {
+		close(i.workerStarted)
+		go i.worker(ctx)
+		if i.cfg.PollInterval > 0 {
+			go i.poller(ctx)
+		}
+	})
 }
 
 func (i *Indexer) IndexAll(ctx context.Context) error {
 	if err := i.ReloadIgnoreRules(); err != nil {
 		return err
 	}
-	done := make(chan error, 1)
-	i.reqCh <- request{ctx: ctx, full: true, done: done}
-	return <-done
+	return i.submitRequest(ctx, request{full: true})
 }
 
 func (i *Indexer) EnsureIndexed(ctx context.Context, relPaths []string) error {
+	return i.submitRequest(ctx, request{paths: relPaths, full: false})
+}
+
+func (i *Indexer) submitRequest(ctx context.Context, req request) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-i.workerStarted:
+	default:
+		return errIndexerNotStarted
+	}
+	select {
+	case <-i.workerDone:
+		return errIndexerStopped
+	default:
+	}
+
 	done := make(chan error, 1)
-	i.reqCh <- request{ctx: ctx, paths: relPaths, full: false, done: done}
-	return <-done
+	req.ctx = ctx
+	req.done = done
+	select {
+	case i.reqCh <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.workerDone:
+		return errIndexerStopped
+	}
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.workerDone:
+		select {
+		case err := <-done:
+			return err
+		default:
+			return errIndexerStopped
+		}
+	}
 }
 
 func (i *Indexer) RemovePaths(relPaths []string) error {
@@ -472,17 +523,22 @@ func dotProduct(a, b []float32) float64 {
 }
 
 func (i *Indexer) worker(ctx context.Context) {
+	defer close(i.workerDone)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case req := <-i.reqCh:
+			executionContext, cancel := context.WithCancel(req.ctx)
+			stopLifecycleCancellation := context.AfterFunc(ctx, cancel)
 			var err error
 			if req.full {
-				err = i.indexAll(req.ctx)
+				err = i.indexAll(executionContext)
 			} else {
-				err = i.indexFiles(req.ctx, req.paths)
+				err = i.indexFiles(executionContext, req.paths)
 			}
+			stopLifecycleCancellation()
+			cancel()
 			req.done <- err
 		}
 	}
@@ -515,6 +571,21 @@ func (i *Indexer) indexFiles(ctx context.Context, relPaths []string) error {
 	totalBytes = i.manifest.TotalBytes
 	rules := i.ignoreRules
 	i.mu.Unlock()
+	evict := func(rel string) {
+		i.mu.Lock()
+		ent, ok := i.manifest.Files[rel]
+		if ok {
+			_ = os.Remove(i.chunkFilePath(ent.ID))
+			i.removeVectorFile(ent.ID)
+			i.manifest.TotalBytes -= ent.Size
+			delete(i.manifest.Files, rel)
+		}
+		i.mu.Unlock()
+		if ok {
+			totalBytes -= ent.Size
+			changed = true
+		}
+	}
 
 	for _, rel := range relPaths {
 		select {
@@ -524,30 +595,37 @@ func (i *Indexer) indexFiles(ctx context.Context, relPaths []string) error {
 		}
 
 		if rules.matchesPath(rel) {
+			evict(rel)
 			continue
 		}
 		if !shouldIndex(rel, i.cfg.PreferredExts, i.cfg.AllowGlobs, i.cfg.DenyGlobs) {
+			evict(rel)
 			continue
 		}
 		abs, err := safeJoin(i.rootAbs, rel)
 		if err != nil {
+			evict(rel)
 			continue
 		}
 		info, err := os.Stat(abs)
-		if err != nil || info.IsDir() {
+		if err != nil || !info.Mode().IsRegular() {
+			evict(rel)
 			continue
 		}
-		if info.Size() > i.cfg.MaxFileBytes {
+		if info.Size() <= 0 || info.Size() > i.cfg.MaxFileBytes {
+			evict(rel)
 			continue
 		}
 		existingSize := i.indexedFileSize(rel)
 		if totalBytes-existingSize+info.Size() > i.cfg.MaxTotalBytes {
+			evict(rel)
 			continue
 		}
 
 		ok, delta, err := i.indexOne(ctx, abs, rel, info)
 		if err != nil {
 			i.setError(err)
+			evict(rel)
 			continue
 		}
 		if ok {

--- a/internal/indexing/indexer_test.go
+++ b/internal/indexing/indexer_test.go
@@ -2,15 +2,128 @@ package indexing
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"memento-mcp/internal/embedding"
 	"memento-mcp/internal/redact"
 )
+
+type lifecycleBlockingEmbedder struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (e *lifecycleBlockingEmbedder) Embed(ctx context.Context, _ embedding.Task, _ []string) ([][]float32, error) {
+	e.once.Do(func() { close(e.started) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (*lifecycleBlockingEmbedder) Fingerprint() string { return "lifecycle-blocking-v1" }
+func (*lifecycleBlockingEmbedder) Name() string        { return "test/lifecycle-blocking" }
+
+func TestIndexerRequestsFailAfterWorkerStops(t *testing.T) {
+	idx, err := New(Config{RootAbs: t.TempDir(), StoreDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerContext, stop := context.WithCancel(context.Background())
+	idx.Start(workerContext)
+	stop()
+	select {
+	case <-idx.workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("indexer worker did not stop")
+	}
+	if err := idx.EnsureIndexed(context.Background(), []string{"fixture.go"}); !errors.Is(err, errIndexerStopped) {
+		t.Fatalf("EnsureIndexed error = %v, want %v", err, errIndexerStopped)
+	}
+	if err := idx.IndexAll(context.Background()); !errors.Is(err, errIndexerStopped) {
+		t.Fatalf("IndexAll error = %v, want %v", err, errIndexerStopped)
+	}
+}
+
+func TestIndexerLifecycleCancellationStopsActiveRequest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.go"), []byte("package fixture\n\nfunc Active() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	embedder := &lifecycleBlockingEmbedder{started: make(chan struct{})}
+	idx, err := New(Config{RootAbs: root, StoreDir: t.TempDir(), Embedder: embedder})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerContext, stop := context.WithCancel(context.Background())
+	idx.Start(workerContext)
+	requestDone := make(chan error, 1)
+	go func() {
+		requestDone <- idx.EnsureIndexed(context.Background(), []string{"fixture.go"})
+	}()
+	select {
+	case <-embedder.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("embedding request did not start")
+	}
+	stop()
+	select {
+	case <-idx.workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("active request kept indexer worker alive after lifecycle cancellation")
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("active EnsureIndexed request did not return after lifecycle cancellation")
+	}
+}
+
+func TestIndexerRequestsRequireStartedWorker(t *testing.T) {
+	idx, err := New(Config{RootAbs: t.TempDir(), StoreDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.EnsureIndexed(context.Background(), []string{"fixture.go"}); !errors.Is(err, errIndexerNotStarted) {
+		t.Fatalf("EnsureIndexed error = %v, want %v", err, errIndexerNotStarted)
+	}
+}
+
+func TestEnsureIndexedEvictsStaleChunksWhenFileBecomesUnindexable(t *testing.T) {
+	root := t.TempDir()
+	store := t.TempDir()
+	path := filepath.Join(root, "fixture.go")
+	if err := os.WriteFile(path, []byte("package fixture\n\nfunc Small() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := New(Config{RootAbs: root, StoreDir: store, MaxFileBytes: 64})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	idx.Start(ctx)
+	if err := idx.EnsureIndexed(ctx, []string{"fixture.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.FileChunks("fixture.go"); err != nil {
+		t.Fatalf("expected initial chunks: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("package fixture\n"+strings.Repeat("x", 128)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.EnsureIndexed(ctx, []string{"fixture.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.FileChunks("fixture.go"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale chunks remained after file exceeded MaxFileBytes: %v", err)
+	}
+}
 
 func TestIndexerIndexesAndSearches(t *testing.T) {
 	root := t.TempDir()

--- a/internal/mcp/diff_context_tool.go
+++ b/internal/mcp/diff_context_tool.go
@@ -1,0 +1,388 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"memento-mcp/internal/indexing"
+)
+
+type diffContextFile struct {
+	Path           string           `json:"path"`
+	TotalChunks    int              `json:"totalChunks"`
+	IncludedChunks int              `json:"includedChunks"`
+	Chunks         []indexing.Chunk `json:"chunks"`
+}
+
+type diffContextSkippedPath struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+func newRepoDiffContextTool(root string, idx *indexing.Indexer) Tool {
+	tool := repoDiffContextToolDefinition()
+	tool.Handler = func(ctx context.Context, raw json.RawMessage) (any, error) {
+		if idx == nil {
+			return nil, fmt.Errorf("repository index is unavailable")
+		}
+		args, err := requireArgs(raw)
+		if err != nil {
+			return nil, err
+		}
+		requestedPaths, ok := asStringSlice(args, "paths")
+		if !ok || len(requestedPaths) == 0 {
+			return nil, fmt.Errorf("missing required argument: paths")
+		}
+		if len(requestedPaths) > defaultRepoDiffContextMaxPaths {
+			return nil, fmt.Errorf("paths exceeds maximum of %d", defaultRepoDiffContextMaxPaths)
+		}
+		paths, rejectedPaths, validationErr := validateDiffContextPaths(root, requestedPaths)
+		if len(rejectedPaths) > 0 {
+			if err := idx.RemovePaths(rejectedPaths); err != nil {
+				return nil, fmt.Errorf("remove stale chunks for rejected paths %s: %w", strings.Join(rejectedPaths, ", "), err)
+			}
+		}
+		if len(paths) > defaultRepoDiffContextMaxPaths {
+			return nil, fmt.Errorf("paths exceeds maximum of %d", defaultRepoDiffContextMaxPaths)
+		}
+
+		maxChunksPerFile := defaultRepoDiffContextMaxChunks
+		if value, ok := asFloat(args, "maxChunksPerFile"); ok && int(value) > 0 {
+			maxChunksPerFile = int(value)
+		}
+		maxTokens := defaultRepoDiffContextMaxTokens
+		if value, ok := asFloat(args, "maxTokens"); ok && int(value) > 0 {
+			maxTokens = int(value)
+		}
+		maxTotalBytes := defaultRepoDiffContextMaxBytes
+		if value, ok := asFloat(args, "maxTotalBytes"); ok && int(value) > 0 {
+			maxTotalBytes = int(value)
+		}
+		focus, _ := asString(args, "focus")
+		focusLower := strings.ToLower(strings.TrimSpace(focus))
+
+		if err := idx.ReloadIgnoreRules(); err != nil {
+			return nil, fmt.Errorf("reload ignore rules: %w", err)
+		}
+		ignored := loadGitIgnored(root)
+		ignoredPaths := make([]string, 0)
+		for _, rel := range paths {
+			if ignored.Matches(rel) {
+				ignoredPaths = append(ignoredPaths, rel)
+			}
+		}
+		if len(ignoredPaths) > 0 {
+			if err := idx.RemovePaths(ignoredPaths); err != nil {
+				return nil, fmt.Errorf("remove stale chunks for Git-ignored paths %s: %w", strings.Join(ignoredPaths, ", "), err)
+			}
+		}
+		if validationErr != nil {
+			return nil, validationErr
+		}
+		if len(ignoredPaths) > 0 {
+			return nil, fmt.Errorf("paths are ignored by Git: %s", strings.Join(ignoredPaths, ", "))
+		}
+		if err := idx.EnsureIndexed(ctx, paths); err != nil {
+			return nil, fmt.Errorf("index requested paths: %w", err)
+		}
+
+		budget := newContextBudget(maxTokens, maxTotalBytes)
+		files := make([]diffContextFile, 0, len(paths))
+		skipped := make([]diffContextSkippedPath, 0)
+		omittedPaths := make([]diffContextSkippedPath, 0)
+		totalChunks := 0
+		includedChunks := 0
+		indexedPaths := 0
+		for _, rel := range paths {
+			chunks, err := idx.FileChunks(rel)
+			if errors.Is(err, os.ErrNotExist) {
+				skipped = append(skipped, diffContextSkippedPath{Path: rel, Reason: "not_indexed"})
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("read indexed chunks for %s: %w", rel, err)
+			}
+			indexedPaths++
+			totalChunks += len(chunks)
+
+			selected := selectChunks(chunks, focusLower, maxChunksPerFile)
+			packed := make([]indexing.Chunk, 0, len(selected))
+			for _, chunk := range selected {
+				if budget.tryAdd(chunk.Content) {
+					packed = append(packed, chunk)
+				}
+			}
+			if len(packed) == 0 {
+				reason := "budget"
+				if len(selected) == 0 {
+					reason = "no_chunks"
+				}
+				omittedPaths = append(omittedPaths, diffContextSkippedPath{Path: rel, Reason: reason})
+				continue
+			}
+			sort.Slice(packed, func(left, right int) bool {
+				return packed[left].StartLine < packed[right].StartLine
+			})
+			includedChunks += len(packed)
+			files = append(files, diffContextFile{
+				Path:           rel,
+				TotalChunks:    len(chunks),
+				IncludedChunks: len(packed),
+				Chunks:         packed,
+			})
+		}
+
+		omittedChunks := totalChunks - includedChunks
+		summary := map[string]any{
+			"requestedPaths": len(paths),
+			"indexedPaths":   indexedPaths,
+			"includedPaths":  len(files),
+			"skippedPaths":   len(skipped),
+			"omittedPaths":   len(omittedPaths),
+			"totalChunks":    totalChunks,
+			"includedChunks": includedChunks,
+			"omittedChunks":  omittedChunks,
+			"text": fmt.Sprintf(
+				"Requested %d paths; returned %d paths and %d of %d indexed chunks; skipped %d paths and omitted %d indexed paths.",
+				len(paths), len(files), includedChunks, totalChunks, len(skipped), len(omittedPaths),
+			),
+		}
+
+		return map[string]any{
+			"paths":        paths,
+			"focus":        focus,
+			"summary":      summary,
+			"files":        files,
+			"skippedPaths": skipped,
+			"omittedPaths": omittedPaths,
+			"limits":       budget.limits(len(paths), maxChunksPerFile),
+		}, nil
+	}
+	return tool
+}
+
+func validateDiffContextPaths(root string, requested []string) ([]string, []string, error) {
+	paths := make([]string, 0, len(requested))
+	rejected := make([]string, 0)
+	seen := make(map[string]struct{}, len(requested))
+	var firstErr error
+	reject := func(rel string, err error) {
+		rejected = append(rejected, rel)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, requestedPath := range requested {
+		rel, err := normalizeDiffContextPath(requestedPath)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if _, duplicate := seen[rel]; duplicate {
+			continue
+		}
+		seen[rel] = struct{}{}
+		abs, err := safeJoin(root, rel)
+		if err != nil {
+			reject(rel, err)
+			continue
+		}
+		if err := rejectSymlinkedPath(root, rel); err != nil {
+			reject(rel, err)
+			continue
+		}
+		inside, err := resolvedPathWithinRoot(root, abs)
+		if err != nil {
+			reject(rel, err)
+			continue
+		}
+		if !inside {
+			reject(rel, fmt.Errorf("path resolves outside workspace: %s", rel))
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			reject(rel, err)
+			continue
+		}
+		if info.IsDir() {
+			reject(rel, fmt.Errorf("path is a directory, expected file: %s", rel))
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			reject(rel, fmt.Errorf("path is not a regular file: %s", rel))
+			continue
+		}
+		paths = append(paths, rel)
+	}
+	return paths, rejected, firstErr
+}
+
+func rejectSymlinkedPath(root, rel string) error {
+	current := root
+	for _, component := range strings.Split(rel, "/") {
+		current = filepath.Join(current, filepath.FromSlash(component))
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path contains a symbolic link: %s", rel)
+		}
+	}
+	return nil
+}
+
+func resolvedPathWithinRoot(root, target string) (bool, error) {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false, err
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedTarget)
+	if err != nil {
+		return false, err
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel), nil
+}
+
+func normalizeDiffContextPath(value string) (string, error) {
+	raw := strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if raw == "" {
+		return "", fmt.Errorf("paths must contain non-empty repo-relative paths")
+	}
+	if strings.HasPrefix(raw, "/") || filepath.IsAbs(filepath.FromSlash(raw)) || looksLikeWindowsAbsolutePath(raw) {
+		return "", fmt.Errorf("path must be repo-relative: %s", value)
+	}
+	rel := path.Clean(raw)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", fmt.Errorf("path resolves outside workspace: %s", value)
+	}
+	return rel, nil
+}
+
+func looksLikeWindowsAbsolutePath(value string) bool {
+	return len(value) >= 3 && value[1] == ':' && value[2] == '/' &&
+		(value[0] >= 'A' && value[0] <= 'Z' || value[0] >= 'a' && value[0] <= 'z')
+}
+
+func repoDiffContextToolDefinition() Tool {
+	return Tool{
+		Name:        "repo_diff_context",
+		Title:       "Get Changed-File Context",
+		Description: "Return compact indexed chunks for an explicit ordered list of changed repo-relative paths. Results never expand to related files. Automatic Git changed-file detection and unified diff summaries are reserved for a later workflow.",
+		Annotations: readOnlyAnnotations(),
+		Meta:        largeResultToolMeta(),
+		InputSchema: map[string]any{
+			"type":     "object",
+			"required": []any{"paths"},
+			"properties": map[string]any{
+				"paths": map[string]any{
+					"type":        "array",
+					"minItems":    1,
+					"maxItems":    defaultRepoDiffContextMaxPaths,
+					"items":       map[string]any{"type": "string"},
+					"description": "Ordered repo-relative changed-file paths. Duplicates are removed after normalization.",
+				},
+				"focus":            map[string]any{"type": "string", "description": "Optional text used to prioritize chunks within each requested file."},
+				"maxChunksPerFile": map[string]any{"type": "integer", "minimum": 1, "description": "Maximum chunks returned per requested file (default 3)."},
+				"maxTokens":        map[string]any{"type": "integer", "minimum": 1, "description": "Approximate content-token budget (default 4000)."},
+				"maxTotalBytes":    map[string]any{"type": "integer", "minimum": 1, "description": "Hard content byte budget (default 16000)."},
+			},
+		},
+		OutputSchema: repoDiffContextOutputSchema(),
+	}
+}
+
+func repoDiffContextOutputSchema() map[string]any {
+	chunk := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path":      map[string]any{"type": "string"},
+			"language":  map[string]any{"type": "string"},
+			"startLine": map[string]any{"type": "integer"},
+			"endLine":   map[string]any{"type": "integer"},
+			"content":   map[string]any{"type": "string"},
+		},
+		"required": []any{"path", "language", "startLine", "endLine", "content"},
+	}
+	countProperties := map[string]any{
+		"requestedPaths": map[string]any{"type": "integer"},
+		"indexedPaths":   map[string]any{"type": "integer"},
+		"includedPaths":  map[string]any{"type": "integer"},
+		"skippedPaths":   map[string]any{"type": "integer"},
+		"omittedPaths":   map[string]any{"type": "integer"},
+		"totalChunks":    map[string]any{"type": "integer"},
+		"includedChunks": map[string]any{"type": "integer"},
+		"omittedChunks":  map[string]any{"type": "integer"},
+		"text":           map[string]any{"type": "string"},
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"paths": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			"focus": map[string]any{"type": "string"},
+			"summary": map[string]any{
+				"type":       "object",
+				"properties": countProperties,
+				"required":   []any{"requestedPaths", "indexedPaths", "includedPaths", "skippedPaths", "omittedPaths", "totalChunks", "includedChunks", "omittedChunks", "text"},
+			},
+			"files": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path":           map[string]any{"type": "string"},
+						"totalChunks":    map[string]any{"type": "integer"},
+						"includedChunks": map[string]any{"type": "integer"},
+						"chunks":         map[string]any{"type": "array", "items": chunk},
+					},
+					"required": []any{"path", "totalChunks", "includedChunks", "chunks"},
+				},
+			},
+			"skippedPaths": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"path": map[string]any{"type": "string"}, "reason": map[string]any{"type": "string"}},
+					"required":   []any{"path", "reason"},
+				},
+			},
+			"omittedPaths": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"path": map[string]any{"type": "string"}, "reason": map[string]any{"type": "string"}},
+					"required":   []any{"path", "reason"},
+				},
+			},
+			"limits": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"maxFiles":         map[string]any{"type": "integer"},
+					"maxChunksPerFile": map[string]any{"type": "integer"},
+					"maxTokens":        map[string]any{"type": "integer"},
+					"usedTokens":       map[string]any{"type": "integer"},
+					"tokenEstimator":   map[string]any{"type": "string"},
+					"maxTotalBytes":    map[string]any{"type": "integer"},
+					"usedBytes":        map[string]any{"type": "integer"},
+					"clamped":          map[string]any{"type": "boolean"},
+				},
+				"required": []any{"maxFiles", "maxChunksPerFile", "maxTokens", "usedTokens", "tokenEstimator", "maxTotalBytes", "usedBytes", "clamped"},
+			},
+		},
+		"required": []any{"paths", "focus", "summary", "files", "skippedPaths", "omittedPaths", "limits"},
+	}
+}

--- a/internal/mcp/diff_context_tool_test.go
+++ b/internal/mcp/diff_context_tool_test.go
@@ -1,0 +1,408 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"memento-mcp/internal/indexing"
+)
+
+type decodedDiffContext struct {
+	Paths   []string `json:"paths"`
+	Summary struct {
+		RequestedPaths int    `json:"requestedPaths"`
+		IndexedPaths   int    `json:"indexedPaths"`
+		IncludedPaths  int    `json:"includedPaths"`
+		SkippedPaths   int    `json:"skippedPaths"`
+		OmittedPaths   int    `json:"omittedPaths"`
+		TotalChunks    int    `json:"totalChunks"`
+		IncludedChunks int    `json:"includedChunks"`
+		OmittedChunks  int    `json:"omittedChunks"`
+		Text           string `json:"text"`
+	} `json:"summary"`
+	Files []struct {
+		Path           string           `json:"path"`
+		TotalChunks    int              `json:"totalChunks"`
+		IncludedChunks int              `json:"includedChunks"`
+		Chunks         []indexing.Chunk `json:"chunks"`
+	} `json:"files"`
+	SkippedPaths []diffContextSkippedPath `json:"skippedPaths"`
+	OmittedPaths []diffContextSkippedPath `json:"omittedPaths"`
+	Limits       struct {
+		MaxFiles         int  `json:"maxFiles"`
+		MaxChunksPerFile int  `json:"maxChunksPerFile"`
+		MaxTokens        int  `json:"maxTokens"`
+		MaxTotalBytes    int  `json:"maxTotalBytes"`
+		Clamped          bool `json:"clamped"`
+	} `json:"limits"`
+}
+
+func setupDiffContextTestRepo(t *testing.T) (string, *indexing.Indexer, context.Context) {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"pkg/a.go": `package pkg
+
+func AOne() {
+	println("one")
+}
+func ATwo() {
+	println("two")
+}
+func AThree() {
+	println("three")
+}
+`,
+		"pkg/b.go": `package pkg
+
+func BOne() {
+	println("one")
+}
+`,
+		"pkg/c.go":  "package pkg\n\nfunc RelatedButUnrequested() {}\n",
+		"notes.bin": "not indexed by the default extension policy\n",
+		"empty.go":  "   \n",
+	}
+	for rel, content := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	idx, err := indexing.New(indexing.Config{
+		RootAbs:       root,
+		StoreDir:      t.TempDir(),
+		MaxChunkLines: 4,
+		MaxChunkBytes: 1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	idx.Start(ctx)
+	return root, idx, ctx
+}
+
+func decodeDiffContext(t *testing.T, result any) decodedDiffContext {
+	t.Helper()
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded decodedDiffContext
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func TestRepoDiffContextReturnsOnlyExplicitPathsWithSummary(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	result, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{
+		"paths":            []string{"pkg/a.go", "pkg/b.go", "./pkg/a.go"},
+		"maxChunksPerFile": 2,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decodeDiffContext(t, result)
+	if strings.Join(got.Paths, ",") != "pkg/a.go,pkg/b.go" {
+		t.Fatalf("normalized paths = %#v", got.Paths)
+	}
+	if len(got.Files) != 2 || got.Files[0].Path != "pkg/a.go" || got.Files[1].Path != "pkg/b.go" {
+		t.Fatalf("expected only requested files in request order, got %#v", got.Files)
+	}
+	for _, file := range got.Files {
+		if file.Path == "pkg/c.go" {
+			t.Fatal("repo_diff_context expanded to an unrequested related file")
+		}
+		if file.IncludedChunks > 2 {
+			t.Fatalf("per-file chunk limit not enforced: %#v", file)
+		}
+		for index := 1; index < len(file.Chunks); index++ {
+			if file.Chunks[index].StartLine < file.Chunks[index-1].StartLine {
+				t.Fatalf("chunks not returned in source order: %#v", file.Chunks)
+			}
+		}
+	}
+	if got.Summary.RequestedPaths != 2 || got.Summary.IndexedPaths != 2 || got.Summary.IncludedPaths != 2 {
+		t.Fatalf("unexpected path summary: %#v", got.Summary)
+	}
+	if got.Summary.TotalChunks <= got.Summary.IncludedChunks || got.Summary.IncludedChunks != 4 {
+		t.Fatalf("unexpected chunk summary: %#v", got.Summary)
+	}
+	if got.Summary.OmittedChunks != got.Summary.TotalChunks-got.Summary.IncludedChunks || got.Summary.Text == "" {
+		t.Fatalf("inconsistent summary: %#v", got.Summary)
+	}
+	if got.Limits.MaxFiles != 2 || got.Limits.MaxChunksPerFile != 2 {
+		t.Fatalf("unexpected limits: %#v", got.Limits)
+	}
+}
+
+func TestRepoDiffContextSkipsExistingUnindexedPaths(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	result, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{
+		"paths": []string{"notes.bin"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decodeDiffContext(t, result)
+	if len(got.Files) != 0 || len(got.SkippedPaths) != 1 || got.SkippedPaths[0].Reason != "not_indexed" {
+		t.Fatalf("expected unsupported file to be reported as skipped, got %#v", got)
+	}
+	if got.Summary.SkippedPaths != 1 || got.Summary.IndexedPaths != 0 {
+		t.Fatalf("unexpected skipped summary: %#v", got.Summary)
+	}
+}
+
+func TestRepoDiffContextReportsBudgetOmissions(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	result, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{
+		"paths":         []string{"pkg/a.go"},
+		"maxTotalBytes": 1,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decodeDiffContext(t, result)
+	if len(got.Files) != 0 || got.Summary.IncludedChunks != 0 || got.Summary.OmittedChunks != got.Summary.TotalChunks {
+		t.Fatalf("expected all chunks to be omitted by the byte budget, got %#v", got)
+	}
+	if got.Summary.OmittedPaths != 1 || len(got.OmittedPaths) != 1 || got.OmittedPaths[0].Reason != "budget" {
+		t.Fatalf("expected the budget-omitted path to be classified, got %#v", got)
+	}
+	if !got.Limits.Clamped || got.Limits.MaxTotalBytes != 1 {
+		t.Fatalf("expected clamped byte budget, got %#v", got.Limits)
+	}
+}
+
+func TestRepoDiffContextPacksFocusMatchBeforeSourceOrder(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	if err := idx.EnsureIndexed(ctx, []string{"pkg/a.go"}); err != nil {
+		t.Fatal(err)
+	}
+	chunks, err := idx.FileChunks("pkg/a.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	focusedBytes := 0
+	for _, chunk := range chunks {
+		if strings.Contains(chunk.Content, "AThree") {
+			focusedBytes = len(chunk.Content)
+			break
+		}
+	}
+	if focusedBytes == 0 {
+		t.Fatal("fixture did not produce a focused chunk")
+	}
+
+	result, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{
+		"paths":            []string{"pkg/a.go"},
+		"focus":            "AThree",
+		"maxChunksPerFile": 3,
+		"maxTotalBytes":    focusedBytes,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decodeDiffContext(t, result)
+	if len(got.Files) != 1 || len(got.Files[0].Chunks) != 1 || !strings.Contains(got.Files[0].Chunks[0].Content, "AThree") {
+		t.Fatalf("expected the exact focus match to win the tight budget, got %#v", got.Files)
+	}
+}
+
+func TestRepoDiffContextRejectsUnsafeOrInvalidPaths(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	if output, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("secret.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secret.go"), []byte("package secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "empty", path: " ", want: "non-empty"},
+		{name: "parent", path: "../outside.go", want: "outside workspace"},
+		{name: "absolute", path: "/tmp/outside.go", want: "repo-relative"},
+		{name: "windows absolute", path: `C:\\tmp\\outside.go`, want: "repo-relative"},
+		{name: "root", path: ".", want: "outside workspace"},
+		{name: "directory", path: "pkg", want: "directory"},
+		{name: "missing", path: "missing.go", want: "no such file"},
+		{name: "ignored", path: "secret.go", want: "ignored by Git"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{"paths": []string{test.path}}))
+			if err == nil || !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(test.want)) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRepoDiffContextRejectsSymlinkPath(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	outsidePath := filepath.Join(t.TempDir(), "outside.go")
+	if err := os.WriteFile(outsidePath, []byte("package outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, filepath.Join(root, "outside-link.go")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{"paths": []string{"outside-link.go"}}))
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("error = %v, want symbolic-link rejection", err)
+	}
+}
+
+func TestRepoDiffContextEvictsNewlyGitIgnoredChunks(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	if output, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	secretPath := filepath.Join(root, "secret.go")
+	if err := os.WriteFile(secretPath, []byte("package secret\n\nconst SecretNeedle = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secondSecretPath := filepath.Join(root, "secret_two.go")
+	if err := os.WriteFile(secondSecretPath, []byte("package secret\n\nconst SecondSecretNeedle = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := newRepoDiffContextTool(root, idx)
+	secretPaths := []string{"secret.go", "secret_two.go"}
+	if _, err := tool.Handler(ctx, rawJSON(t, map[string]any{"paths": secretPaths})); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("secret.go\nsecret_two.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tool.Handler(ctx, rawJSON(t, map[string]any{"paths": secretPaths})); err == nil || !strings.Contains(err.Error(), "ignored by Git") {
+		t.Fatalf("error = %v, want Git-ignore rejection", err)
+	}
+	for _, rel := range secretPaths {
+		if _, err := idx.FileChunks(rel); !os.IsNotExist(err) {
+			t.Fatalf("stale ignored chunks remained for %s: %v", rel, err)
+		}
+	}
+	results, err := idx.SearchContext(ctx, "SecretNeedle", 10, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("ignored content remained searchable: %#v", results)
+	}
+}
+
+func TestRepoDiffContextEvictsDeletedCachedPathBeforeReturningError(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	deletedPath := filepath.Join(root, "deleted.go")
+	if err := os.WriteFile(deletedPath, []byte("package deleted\n\nconst DeletedNeedle = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := newRepoDiffContextTool(root, idx)
+	if _, err := tool.Handler(ctx, rawJSON(t, map[string]any{"paths": []string{"deleted.go"}})); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(deletedPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tool.Handler(ctx, rawJSON(t, map[string]any{"paths": []string{"deleted.go"}})); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("error = %v, want missing-file error", err)
+	}
+	if _, err := idx.FileChunks("deleted.go"); !os.IsNotExist(err) {
+		t.Fatalf("deleted path retained stale chunks: %v", err)
+	}
+	results, err := idx.SearchContext(ctx, "DeletedNeedle", 10, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("deleted content remained searchable: %#v", results)
+	}
+}
+
+func TestRepoDiffContextReportsNoChunkOmission(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	result, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{"paths": []string{"empty.go"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decodeDiffContext(t, result)
+	if got.Summary.OmittedPaths != 1 || len(got.OmittedPaths) != 1 || got.OmittedPaths[0].Reason != "no_chunks" {
+		t.Fatalf("expected no_chunks omission, got %#v", got)
+	}
+}
+
+func TestRepoDiffContextRejectsTooManyRawPaths(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	paths := make([]string, defaultRepoDiffContextMaxPaths+1)
+	for index := range paths {
+		paths[index] = "pkg/a.go"
+	}
+	_, err := newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{"paths": paths}))
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("error = %v, want maximum-path rejection", err)
+	}
+}
+
+func TestRepoDiffContextRejectsNonRegularPath(t *testing.T) {
+	root, idx, ctx := setupDiffContextTestRepo(t)
+	socketPath := filepath.Join(root, "socket.go")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("Unix sockets unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	_, err = newRepoDiffContextTool(root, idx).Handler(ctx, rawJSON(t, map[string]any{"paths": []string{"socket.go"}}))
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("error = %v, want non-regular-file rejection", err)
+	}
+}
+
+func TestRepoDiffContextToolDefinitionContract(t *testing.T) {
+	tool := repoDiffContextToolDefinition()
+	if tool.Name != "repo_diff_context" || tool.OutputSchema == nil {
+		t.Fatalf("unexpected tool definition: %#v", tool)
+	}
+	got, _ := tool.Meta["anthropic/maxResultSizeChars"].(int)
+	if got != defaultAnthropicMaxResultSizeChars {
+		t.Fatalf("large-result metadata = %#v", tool.Meta)
+	}
+	properties := tool.InputSchema["properties"].(map[string]any)
+	paths := properties["paths"].(map[string]any)
+	if paths["maxItems"] != defaultRepoDiffContextMaxPaths {
+		t.Fatalf("paths schema = %#v", paths)
+	}
+	outputProperties := tool.OutputSchema["properties"].(map[string]any)
+	if _, ok := outputProperties["omittedPaths"]; !ok {
+		t.Fatalf("output schema omitted omittedPaths: %#v", outputProperties)
+	}
+	required := tool.OutputSchema["required"].([]any)
+	foundRequired := false
+	for _, name := range required {
+		if name == "omittedPaths" {
+			foundRequired = true
+			break
+		}
+	}
+	if !foundRequired {
+		t.Fatalf("output schema does not require omittedPaths: %#v", required)
+	}
+}

--- a/internal/mcp/output_limits.go
+++ b/internal/mcp/output_limits.go
@@ -5,6 +5,10 @@ const (
 
 	defaultRepoContextMaxTokens      = 7_000
 	defaultRepoContextMaxTotalBytes  = 32_000
+	defaultRepoDiffContextMaxTokens  = 4_000
+	defaultRepoDiffContextMaxBytes   = 16_000
+	defaultRepoDiffContextMaxPaths   = 20
+	defaultRepoDiffContextMaxChunks  = 3
 	defaultRepoReadFileMaxBytes      = 32_000
 	defaultRepoSearchMaxSnippetBytes = 500
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -80,6 +80,7 @@ type Server struct {
 
 	backgroundParentCtx context.Context
 	backgroundCancel    context.CancelFunc
+	backgroundStartOnce sync.Once
 
 	executable        string
 	childIdleTimeout  time.Duration
@@ -211,19 +212,21 @@ func resolveStartupWorkspaceRoot(configRoot string) (string, workspaceRootSource
 }
 
 func (s *Server) StartBackgroundIndexing(ctx context.Context) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	s.backgroundParentCtx = ctx
-	if s.mode == serverModeBroker {
-		go s.reapIdleChildren(ctx)
-		go func() {
-			<-ctx.Done()
-			s.shutdown()
-		}()
-		return
-	}
-	s.restartBackgroundIndexing()
+	s.backgroundStartOnce.Do(func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		s.backgroundParentCtx = ctx
+		if s.mode == serverModeBroker {
+			go s.reapIdleChildren(ctx)
+			go func() {
+				<-ctx.Done()
+				s.shutdown()
+			}()
+			return
+		}
+		s.restartBackgroundIndexing()
+	})
 }
 
 func normalizeWorkspaceRoot(root string) (string, error) {
@@ -271,6 +274,7 @@ func (s *Server) leafToolsetFor(root string, idx *indexing.Indexer, mem *NoteSto
 		newRepoRelatedFilesTool(root),
 		newRepoOutlineTool(root, s.redactor),
 		newRepoContextTool(root, idx, s.redactor),
+		newRepoDiffContextTool(root, idx),
 		newRepoIndexStatusTool(idx),
 		newRepoReindexTool(idx),
 		newRepoClearIndexTool(idx),
@@ -1075,6 +1079,7 @@ const serverInstructions = `Use when a coding task needs repository-specific con
 
 Repository context:
 - Start with repo_context for an active file; set intent to navigate, implement, or review.
+- Use repo_diff_context when the caller already knows the changed repo-relative paths and needs compact context from only those files.
 - Use repo_outline to inspect signatures and file structure without function bodies before requesting full source.
 - Use repo_search to find text or symbols across workspace files, repo_read_file for an exact path, repo_list_files to map structure, and repo_related_files for imports, importers, same-directory files, and semantic references.
 - If context looks stale or incomplete, use repo_index_status, repo_reindex, or repo_index_debug. repo_clear_index is destructive.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestToolsListIncludesMetadata(t *testing.T) {
@@ -122,9 +123,10 @@ func TestLargeResultToolsAdvertiseAnthropicMaxResultSize(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"repo_context":   false,
-		"repo_read_file": false,
-		"repo_search":    false,
+		"repo_context":      false,
+		"repo_diff_context": false,
+		"repo_read_file":    false,
+		"repo_search":       false,
 	}
 	for _, tool := range decoded.Tools {
 		if _, ok := want[tool.Name]; !ok {
@@ -458,6 +460,25 @@ func TestNewServerUsesClaudeProjectDir(t *testing.T) {
 	s.StartBackgroundIndexing(context.Background())
 	if got := s.root; got != dir {
 		t.Fatalf("expected root %s from CLAUDE_PROJECT_DIR, got %s", dir, got)
+	}
+}
+
+func TestStartBackgroundIndexingIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.go"), []byte("package fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewServer(Config{Root: root, Child: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.shutdown() })
+	s.StartBackgroundIndexing(context.Background())
+	s.StartBackgroundIndexing(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.idx.EnsureIndexed(ctx, []string{"fixture.go"}); err != nil {
+		t.Fatalf("second StartBackgroundIndexing stopped the active indexer: %v", err)
 	}
 }
 

--- a/internal/mcp/tool_coverage_test.go
+++ b/internal/mcp/tool_coverage_test.go
@@ -66,6 +66,7 @@ func TestServerExposesExpectedTools(t *testing.T) {
 		"repo_related_files",
 		"repo_outline",
 		"repo_context",
+		"repo_diff_context",
 		"repo_switch_workspace",
 		"repo_index_status",
 		"repo_reindex",

--- a/internal/mcp/tool_definitions.go
+++ b/internal/mcp/tool_definitions.go
@@ -8,6 +8,7 @@ func leafToolDefinitionsFor(root string, feedbackEnabled bool) []Tool {
 		cloneToolDefinition(newRepoRelatedFilesTool(root)),
 		repoOutlineToolDefinition(),
 		repoContextToolDefinition(),
+		repoDiffContextToolDefinition(),
 		repoIndexStatusToolDefinition(),
 		repoReindexToolDefinition(),
 		repoClearIndexToolDefinition(),


### PR DESCRIPTION
## Summary

- add `repo_diff_context` for ordered, explicit changed paths with bounded exact-file chunks and a structured summary
- harden path validation, stale-index eviction, worker lifecycle cancellation, and ignore-file refresh handling
- document the tool and refresh retrieval fixtures/baseline with explicit rationale

## Why

Edit and review workflows need changed-file-centered context without graph expansion. This slice keeps the scope deterministic and prevents stale, ignored, deleted, or symlinked content from leaking through cached chunks.

## Behavior

- explicit paths only; automatic Git/diff discovery remains deferred to Slice 14B
- limits: 20 paths, 3 chunks per file by default, 4,000 tokens, and 16,000 bytes
- relevance-first packing with accepted chunks returned in source order
- reports skipped and omitted paths with stable reasons

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./... -count=1`
- `go run ./cmd/retrieval-eval -json-out /tmp/memento-diff-context-retrieval.json`
- retrieval output exactly matches `evaluation/baselines/retrieval-ci-v1.json`
- `make evaluation-ci EVALUATION_OUT=/tmp/memento-evaluation-diff-context-merge`
- final retrieval metrics: precision@5 0.5, recall@5 1.0, MRR 1.0, nDCG 0.976506
- three independent review tracks completed cleanly