### PR TITLE
fix: keep Claude plugin releases current

### DIFF
--- a/.github/workflows/claude-plugin.yml
+++ b/.github/workflows/claude-plugin.yml
@@ -76,17 +76,18 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          go build -tags="$TREE_SITTER_TAGS" -ldflags "-X memento-mcp/internal/mcp.serverVersion=0.8.0" -o dist/memento-mcp ./cmd/server
+          VERSION="$(node -p 'require("./plugins/memento/.claude-plugin/plugin.json").version')"
+          go build -tags="$TREE_SITTER_TAGS" -ldflags "-X memento-mcp/internal/mcp.serverVersion=$VERSION" -o dist/memento-mcp ./cmd/server
           request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"plugin-ci","version":"1"}}}'
           printf '%s\n' "$request" | \
             MEMENTO_PLUGIN_BINARY="$PWD/dist/memento-mcp" \
             MEMENTO_PLUGIN_DATA="$RUNNER_TEMP/memento-plugin-data" \
             node plugins/memento/bin/memento-launcher.cjs > "$RUNNER_TEMP/initialize.json"
-          node -e '
+          MEMENTO_EXPECTED_VERSION="$VERSION" node -e '
             const fs = require("node:fs");
             const messages = fs.readFileSync(process.argv[1], "utf8").trim().split("\n").map(JSON.parse);
             const reply = messages.find((message) => message.id === 1);
-            if (!reply?.result?.capabilities?.tools || !reply.result.capabilities.resources || !reply.result.capabilities.prompts || reply.result.serverInfo?.version !== "0.8.0") {
+            if (!reply?.result?.capabilities?.tools || !reply.result.capabilities.resources || !reply.result.capabilities.prompts || reply.result.serverInfo?.version !== process.env.MEMENTO_EXPECTED_VERSION) {
               throw new Error("launcher initialize response omitted expected MCP capabilities or release version");
             }
           ' "$RUNNER_TEMP/initialize.json"

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -12,7 +12,23 @@ permissions:
   contents: write
 
 jobs:
+  validate-claude-plugin-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tagged release commit
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Validate native Claude plugin release version
+        run: node scripts/verify-claude-plugin-release.mjs
+
   build-binaries:
+    needs: validate-claude-plugin-release
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -61,6 +77,7 @@ jobs:
           path: dist/*
 
   package-deb:
+    needs: validate-claude-plugin-release
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -122,6 +139,7 @@ jobs:
           path: dist/*.deb
 
   package-macos-pkg:
+    needs: validate-claude-plugin-release
     if: ${{ vars.MACOS_NOTARIZATION_ENABLED == 'true' }}
     runs-on: macos-latest
     environment:
@@ -264,7 +282,7 @@ jobs:
           path: dist/*.pkg
 
   publish:
-    needs: [build-binaries, package-deb, package-macos-pkg]
+    needs: [validate-claude-plugin-release, build-binaries, package-deb, package-macos-pkg]
     if: ${{ always() && needs.build-binaries.result == 'success' && needs.package-deb.result == 'success' && (needs.package-macos-pkg.result == 'success' || needs.package-macos-pkg.result == 'skipped') }}
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add this repository as a Claude Code marketplace, install Memento, then reload a
 /mcp
 ```
 
-The enabled plugin starts Memento automatically for each Claude Code project. On first start it downloads the version-pinned prebuilt binary for x64 or arm64 macOS, Linux, or Windows, verifies the release SHA-256 checksum, and caches it in Claude Code's persistent plugin data directory. The first start requires GitHub access; later starts verify the cache and work offline.
+The enabled plugin starts Memento automatically for each Claude Code project. On first start it downloads the version-pinned prebuilt binary for x64 or arm64 macOS, Linux, or Windows, verifies the release SHA-256 checksum, and caches it in Claude Code's persistent plugin data directory. The first start requires GitHub access; later starts verify the cache and work offline. New marketplace installs also perform one background check per 24 hours after the MCP server starts and stage any available plugin update. The active task keeps its current binary; reload plugins or start a new task to activate the staged plugin update. Legacy marketplace installs remain opted out until `$HOME/.memento-mcp/marketplace-update.json` contains `{ "autoUpdate": true }`.
 
 ### Claude Code workflows plugin (no native binary)
 
@@ -80,7 +80,7 @@ Update a standalone installation in place:
 memento-mcp update
 ```
 
-Use `memento-mcp update --check` to check without installing. Release builds also perform a silent, throttled check at server startup and write only an update-available notice to stderr; they never write update messages to MCP stdout. Set `MEMENTO_UPDATE_CHECK=false` to disable that check. Claude Code plugin installations remain version-pinned and must be updated through `/plugin` commands.
+Use `memento-mcp update --check` to check without installing. Release builds also perform a silent, throttled check at server startup and write only an update-available notice to stderr; they never write update messages to MCP stdout. Set `MEMENTO_UPDATE_CHECK=false` to disable that check. Claude Code marketplace installs stage plugin updates in the background once per day after startup; use `/plugin` commands to update immediately, then reload plugins or start a new task.
 
 ### Build from source
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -38,7 +38,7 @@ Adicione este repositório como marketplace do Claude Code, instale o Memento e 
 /mcp
 ```
 
-O plugin habilitado inicia o Memento automaticamente em cada projeto. Na primeira inicialização, ele baixa o binário pré-compilado e versionado para macOS, Linux ou Windows em x64 ou arm64, verifica o checksum SHA-256 da release e o armazena no diretório persistente de dados do plugin. O primeiro uso requer acesso ao GitHub; os próximos verificam o cache e funcionam offline.
+O plugin habilitado inicia o Memento automaticamente em cada projeto. Na primeira inicialização, ele baixa o binário pré-compilado e versionado para macOS, Linux ou Windows em x64 ou arm64, verifica o checksum SHA-256 da release e o armazena no diretório persistente de dados do plugin. O primeiro uso requer acesso ao GitHub; os próximos verificam o cache e funcionam offline. Novas instalações pelo marketplace verificam atualizações em segundo plano uma vez a cada 24 horas após o MCP iniciar e deixam a atualização agendada do plugin pronta para uso. A tarefa atual mantém seu binário; recarregue os plugins ou inicie uma nova tarefa para ativar a atualização. Instalações antigas do marketplace permanecem desativadas até que `$HOME/.memento-mcp/marketplace-update.json` contenha `{ "autoUpdate": true }`.
 
 ### Plugin de workflows do Claude Code (sem binário nativo)
 
@@ -73,7 +73,7 @@ Atualize uma instalação independente no próprio local:
 memento-mcp update
 ```
 
-Use `memento-mcp update --check` para apenas verificar, sem instalar. Builds de release também fazem uma verificação silenciosa e limitada a uma vez por dia ao iniciar o servidor, escrevendo um aviso somente no stderr quando houver atualização; mensagens de atualização nunca são escritas no stdout do MCP. Defina `MEMENTO_UPDATE_CHECK=false` para desativar essa verificação. Instalações pelo plugin do Claude Code continuam fixadas por versão e devem ser atualizadas pelos comandos `/plugin`.
+Use `memento-mcp update --check` para apenas verificar, sem instalar. Builds de release também fazem uma verificação silenciosa e limitada a uma vez por dia ao iniciar o servidor, escrevendo um aviso somente no stderr quando houver atualização; mensagens de atualização nunca são escritas no stdout do MCP. Defina `MEMENTO_UPDATE_CHECK=false` para desativar essa verificação. Instalações pelo marketplace do Claude Code deixam atualizações do plugin agendadas em segundo plano; use os comandos `/plugin` para atualizar imediatamente e depois recarregue os plugins ou inicie uma nova tarefa.
 
 ### Compilação a partir do código-fonte
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -94,6 +94,8 @@ The marketplace and plugin are maintained in this repository. When enabled, the 
 
 The plugin pins its launcher and server to the same version. On first start, the launcher detects x64 or arm64 macOS, Linux, or Windows, downloads that version's prebuilt server from the GitHub release, verifies its SHA-256 sidecar, and stores both under `${CLAUDE_PLUGIN_DATA}`. Every later start rehashes the cached executable. A valid cache works offline; a missing or invalid cache requires GitHub access so the launcher can replace it. Go is not required for plugin users.
 
+New marketplace installs check once per 24 hours for an updated marketplace package after the verified MCP server has spawned. The check stages the package using Claude's normal plugin commands, never changes the binary running in the active task, and never blocks MCP startup. Reload plugins or start a new task to activate a staged plugin update. Legacy marketplace installs remain opted out until `$HOME/.memento-mcp/marketplace-update.json` contains `{ "autoUpdate": true }`; unavailable networks, command failures, and timeouts preserve the current server.
+
 Update an installed plugin with:
 
 ```text

--- a/plugins/memento/README.md
+++ b/plugins/memento/README.md
@@ -6,6 +6,8 @@ This plugin starts Memento automatically for every Claude Code project where the
 
 The supported targets are x64 and arm64 on macOS, Linux, and Windows. The first start requires access to the GitHub release; later starts use the verified cached binary and work offline.
 
+New marketplace installs check for a Memento plugin update in the background once per 24 hours, after the verified MCP server has started. The check refreshes the marketplace and stages the package update; it never replaces the binary of the active task. Reload plugins or start a new task to activate a staged plugin update. Legacy marketplace installs remain opted out until you create `$HOME/.memento-mcp/marketplace-update.json` with `{ "autoUpdate": true }`. Network, timeout, or update-command failures leave the working server untouched.
+
 From Claude Code:
 
 ```text
@@ -17,7 +19,7 @@ From Claude Code:
 
 The bundled server is registered as `plugin:memento:memento`. Plugin-scoped MCP tools use names such as `mcp__plugin_memento_memento__repo_context`, and the prime prompt is `/mcp__plugin_memento_memento__prime`.
 
-Update the marketplace and plugin, then reconnect it in the current session:
+To update immediately, update the marketplace and plugin, then reload plugins or start a new task:
 
 ```text
 /plugin marketplace update memento-mcp
@@ -25,7 +27,7 @@ Update the marketplace and plugin, then reconnect it in the current session:
 /reload-plugins
 ```
 
-If first start fails, inspect Memento in `/plugin` and confirm the pinned GitHub release is reachable. A missing or corrupted cache is downloaded again automatically.
+If first start fails, inspect Memento in `/plugin` and confirm the pinned GitHub release is reachable. A missing or corrupted cache is downloaded again automatically. An existing task-local Memento snapshot that predates staged updates must be removed and replaced once.
 
 For local plugin development, validate and launch against a locally built server:
 

--- a/plugins/memento/bin/memento-launcher.cjs
+++ b/plugins/memento/bin/memento-launcher.cjs
@@ -6,6 +6,7 @@ const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const http = require("node:http");
 const https = require("node:https");
+const os = require("node:os");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
 
@@ -18,6 +19,182 @@ const MAX_REDIRECTS = 5;
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 const LOCK_WAIT_MS = 75_000;
 const LOCK_RETRY_MS = 200;
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const UPDATE_CHECK_DEADLINE_MS = 30_000;
+const UPDATE_STATE_FILE = "marketplace-update-state.json";
+
+function marketplaceUpdateStatePath(pluginData) {
+  return path.join(pluginData, UPDATE_STATE_FILE);
+}
+
+async function readJSON(filename) {
+  try {
+    return JSON.parse(await fsp.readFile(filename, "utf8"));
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function writeJSONAtomic(filename, value) {
+  await fsp.mkdir(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = `${filename}.tmp-${process.pid}-${crypto.randomBytes(6).toString("hex")}`;
+  try {
+    await fsp.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+    await fsp.rename(temporary, filename);
+  } catch (error) {
+    await fsp.rm(temporary, { force: true });
+    throw error;
+  }
+}
+
+function normalizedUpdateState(value = {}) {
+  const state = {
+    currentVersion: typeof value.currentVersion === "string" ? value.currentVersion : RELEASE_VERSION,
+    effectivePolicy: value.effectivePolicy === true,
+    policyProvenance: typeof value.policyProvenance === "string" ? value.policyProvenance : "legacy-marketplace-install",
+    result: typeof value.result === "string" ? value.result : "never",
+  };
+  for (const key of ["availableVersion", "lastCheckedAt"]) {
+    if (typeof value[key] === "string" && value[key] !== "") state[key] = value[key];
+  }
+  return state;
+}
+
+async function persistUpdateState(pluginData, value) {
+  const state = normalizedUpdateState(value);
+  await writeJSONAtomic(marketplaceUpdateStatePath(pluginData), state);
+  return state;
+}
+
+async function initializeUpdateState({ pluginData, home = os.homedir(), pluginDataExisted }) {
+  const preference = await readJSON(path.join(home, ".memento-mcp", "marketplace-update.json"));
+  const persisted = await readJSON(marketplaceUpdateStatePath(pluginData));
+  let effectivePolicy;
+  let policyProvenance;
+  if (preference && typeof preference.autoUpdate === "boolean") {
+    effectivePolicy = preference.autoUpdate;
+    policyProvenance = "setup-preference";
+  } else if (persisted && typeof persisted.effectivePolicy === "boolean") {
+    effectivePolicy = persisted.effectivePolicy;
+    policyProvenance = persisted.policyProvenance;
+  } else if (pluginDataExisted) {
+    effectivePolicy = false;
+    policyProvenance = "legacy-marketplace-install";
+  } else {
+    effectivePolicy = true;
+    policyProvenance = "new-marketplace-install";
+  }
+  return persistUpdateState(pluginData, {
+    ...(persisted || {}),
+    currentVersion: RELEASE_VERSION,
+    effectivePolicy,
+    policyProvenance,
+  });
+}
+
+async function acquireUpdateLock(lockFilename) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const handle = await fsp.open(lockFilename, "wx", 0o600);
+      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+      return handle;
+    } catch (error) {
+      if (!error || error.code !== "EEXIST") throw error;
+      if (await lockOwnerAlive(lockFilename)) return null;
+      await fsp.rm(lockFilename, { force: true });
+    }
+  }
+  return null;
+}
+
+function commandResult(command, args, { timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"], windowsHide: true });
+    const stdout = [];
+    const stderr = [];
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(Object.assign(new Error("marketplace update deadline exceeded"), { code: "ETIMEDOUT" }));
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve({ stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") });
+        return;
+      }
+      reject(Object.assign(new Error(`${command} exited ${code === null ? signal : code}`), { code: "COMMAND_FAILED" }));
+    });
+  });
+}
+
+function withDeadline(operation, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(Object.assign(new Error("marketplace update deadline exceeded"), { code: "ETIMEDOUT" })), timeoutMs);
+    Promise.resolve().then(operation).then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+function versionFromText(text) {
+  return (String(text || "").match(/\b\d+\.\d+\.\d+\b/g) || []).at(-1) || RELEASE_VERSION;
+}
+
+function updateFailureResult(error) {
+  if (error && error.code === "ETIMEDOUT") return "deadline";
+  if (error && ["ENETUNREACH", "ENOTFOUND", "ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH"].includes(error.code)) return "offline";
+  return "failed";
+}
+
+async function runMarketplaceUpdateCheck({ pluginData, now = () => new Date(), commandRunner = commandResult, deadlineMs = UPDATE_CHECK_DEADLINE_MS }) {
+  let state = normalizedUpdateState(await readJSON(marketplaceUpdateStatePath(pluginData)) || {});
+  if (!state.effectivePolicy) return state;
+  const currentTime = now();
+  const lastChecked = Date.parse(state.lastCheckedAt || "");
+  if (Number.isFinite(lastChecked) && currentTime.getTime() - lastChecked < UPDATE_CHECK_INTERVAL_MS) return state;
+
+  const lockFilename = path.join(pluginData, "marketplace-update-state.lock");
+  const lock = await acquireUpdateLock(lockFilename);
+  if (!lock) return state;
+  try {
+    state = normalizedUpdateState(await readJSON(marketplaceUpdateStatePath(pluginData)) || state);
+    const lockedLastChecked = Date.parse(state.lastCheckedAt || "");
+    if (Number.isFinite(lockedLastChecked) && currentTime.getTime() - lockedLastChecked < UPDATE_CHECK_INTERVAL_MS) return state;
+
+    const next = await persistUpdateState(pluginData, {
+      ...state,
+      currentVersion: RELEASE_VERSION,
+      lastCheckedAt: currentTime.toISOString(),
+    });
+    const deadline = Date.now() + deadlineMs;
+    const invoke = (command, args) => {
+      const timeoutMs = Math.max(1, deadline - Date.now());
+      return withDeadline(() => commandRunner(command, args, { timeoutMs }), timeoutMs);
+    };
+    try {
+      const refresh = await invoke("claude", ["plugin", "marketplace", "update", "memento-mcp"]);
+      const staged = await invoke("claude", ["plugin", "update", "memento@memento-mcp"]);
+      return persistUpdateState(pluginData, {
+        ...next,
+        availableVersion: versionFromText(`${refresh.stdout}\n${refresh.stderr}\n${staged.stdout}\n${staged.stderr}`),
+        result: "staged",
+      });
+    } catch (error) {
+      return persistUpdateState(pluginData, { ...next, result: updateFailureResult(error) });
+    }
+  } finally {
+    await lock.close().catch(() => {});
+    await fsp.rm(lockFilename, { force: true });
+  }
+}
 
 function resolveTarget(platform = process.platform, arch = process.arch) {
   const os = { darwin: "darwin", linux: "linux", win32: "windows" }[platform];
@@ -271,27 +448,71 @@ async function resolveBinary(options = {}) {
   }
 }
 
-async function run() {
-  const binary = await resolveBinary();
-  const child = spawn(binary, [], {
-    cwd: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
-    env: process.env,
+function startServerProcess(binary, options = {}) {
+  const child = (options.spawnServer || spawn)(binary, [], {
+    cwd: options.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+    env: options.env || process.env,
     stdio: "inherit",
     windowsHide: true,
   });
-
-  for (const signal of ["SIGINT", "SIGTERM"]) {
-    process.on(signal, () => {
-      if (!child.killed) child.kill(signal);
-    });
+  child.once("spawn", () => {
+    Promise.resolve()
+      .then(() => options.backgroundCheck && options.backgroundCheck())
+      .catch((error) => (options.notice || ((message) => process.stderr.write(`${message}\n`)))(`memento plugin update check failed: ${error.message}`));
+  });
+  const forwarders = new Map();
+  if (options.forwardSignals !== false) {
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      const forward = () => {
+        if (!child.killed) child.kill(signal);
+      };
+      forwarders.set(signal, forward);
+      process.on(signal, forward);
+    }
   }
-
-  await new Promise((resolve, reject) => {
-    child.once("error", reject);
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      for (const [signal, forward] of forwarders) process.off(signal, forward);
+    };
+    child.once("error", (error) => {
+      cleanup();
+      reject(error);
+    });
     child.once("exit", (code, signal) => {
+      cleanup();
       process.exitCode = code === null ? (signal ? 1 : 0) : code;
       resolve();
     });
+  });
+}
+
+async function hasLegacyPluginCache(pluginData) {
+  try {
+    return (await fsp.stat(path.join(pluginData, "bin"))).isDirectory();
+  } catch (error) {
+    if (error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function run(options = {}) {
+  const env = options.env || process.env;
+  const pluginData = options.pluginData || env.MEMENTO_PLUGIN_DATA;
+  const override = options.override || env.MEMENTO_PLUGIN_BINARY;
+  const pluginDataExisted = pluginData ? await hasLegacyPluginCache(pluginData) : false;
+  const binary = await (options.resolveBinary || resolveBinary)({ ...options, pluginData, override });
+  return startServerProcess(binary, {
+    ...options,
+    env,
+    backgroundCheck: override || !pluginData ? undefined : async () => {
+      await initializeUpdateState({ pluginData, home: options.home, pluginDataExisted });
+      await runMarketplaceUpdateCheck({
+        pluginData,
+        now: options.now,
+        commandRunner: options.commandRunner,
+        deadlineMs: options.deadlineMs,
+      });
+    },
   });
 }
 
@@ -306,10 +527,15 @@ module.exports = {
   RELEASE_TAG,
   RELEASE_VERSION,
   acquireInstallLock,
+  hasLegacyPluginCache,
+  initializeUpdateState,
   isVerified,
+  marketplaceUpdateStatePath,
   parseChecksum,
   requestBuffer,
   resolveBinary,
   resolveTarget,
   run,
+  runMarketplaceUpdateCheck,
+  startServerProcess,
 };

--- a/plugins/memento/test/launcher.test.cjs
+++ b/plugins/memento/test/launcher.test.cjs
@@ -7,14 +7,200 @@ const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const { EventEmitter } = require("node:events");
 
 const {
   RELEASE_VERSION,
+  hasLegacyPluginCache,
+  initializeUpdateState,
   isVerified,
+  marketplaceUpdateStatePath,
   parseChecksum,
   resolveBinary,
   resolveTarget,
+  run,
+  runMarketplaceUpdateCheck,
+  startServerProcess,
 } = require("../bin/memento-launcher.cjs");
+
+async function writeSetupPreference(home, autoUpdate) {
+  const filename = path.join(home, ".memento-mcp", "marketplace-update.json");
+  await fsp.mkdir(path.dirname(filename), { recursive: true });
+  await fsp.writeFile(filename, `${JSON.stringify({ autoUpdate })}\n`, { mode: 0o600 });
+}
+
+function recordingRunner(responses, calls) {
+  return async (command, args, options) => {
+    calls.push({ command, args, timeoutMs: options.timeoutMs });
+    const response = responses.shift();
+    if (response instanceof Error) throw response;
+    return response || { stdout: "", stderr: "" };
+  };
+}
+
+test("new marketplace installs persist an enabled update policy while legacy installs remain off", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "memento-plugin-update-policy-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const newPluginData = path.join(root, "new-plugin-data");
+  const legacyPluginData = path.join(root, "legacy-plugin-data");
+  const home = path.join(root, "home");
+  await fsp.mkdir(newPluginData);
+  await fsp.mkdir(legacyPluginData);
+  await fsp.mkdir(path.join(legacyPluginData, "bin"));
+
+  const fresh = await initializeUpdateState({ pluginData: newPluginData, home, pluginDataExisted: await hasLegacyPluginCache(newPluginData) });
+  const legacy = await initializeUpdateState({ pluginData: legacyPluginData, home, pluginDataExisted: await hasLegacyPluginCache(legacyPluginData) });
+
+  assert.equal(fresh.effectivePolicy, true);
+  assert.equal(fresh.policyProvenance, "new-marketplace-install");
+  assert.equal(legacy.effectivePolicy, false);
+  assert.equal(legacy.policyProvenance, "legacy-marketplace-install");
+  assert.equal((await fsp.stat(marketplaceUpdateStatePath(newPluginData))).mode & 0o777, 0o600);
+
+  await writeSetupPreference(home, true);
+  const optedIn = await initializeUpdateState({ pluginData: legacyPluginData, home, pluginDataExisted: await hasLegacyPluginCache(legacyPluginData) });
+  assert.equal(optedIn.effectivePolicy, true);
+  assert.equal(optedIn.policyProvenance, "setup-preference");
+});
+
+test("only an existing server cache classifies plugin data as legacy", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "memento-plugin-update-provenance-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const emptyPluginData = path.join(root, "empty-plugin-data");
+  const cachedPluginData = path.join(root, "cached-plugin-data");
+  await fsp.mkdir(emptyPluginData);
+  await fsp.mkdir(path.join(cachedPluginData, "bin"), { recursive: true });
+
+  assert.equal(await hasLegacyPluginCache(emptyPluginData), false);
+  assert.equal(await hasLegacyPluginCache(cachedPluginData), true);
+});
+
+test("a pre-created empty plugin-data directory remains a new installation at runtime", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "memento-plugin-update-runtime-provenance-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const pluginData = path.join(root, "plugin-data");
+  await fsp.mkdir(pluginData);
+  const child = new EventEmitter();
+  child.killed = false;
+  child.kill = () => { child.killed = true; };
+  let commands = 0;
+  let safetyExit;
+
+  await run({
+    env: { MEMENTO_PLUGIN_DATA: pluginData },
+    home: path.join(root, "home"),
+    resolveBinary: async () => "/verified/memento-mcp",
+    spawnServer: () => {
+      queueMicrotask(() => {
+        child.emit("spawn");
+        safetyExit = setTimeout(() => child.emit("exit", 0, null), 100);
+      });
+      return child;
+    },
+    commandRunner: async () => {
+      commands += 1;
+      if (commands === 2) {
+        clearTimeout(safetyExit);
+        queueMicrotask(() => child.emit("exit", 0, null));
+      }
+      return { stdout: "Updated memento@memento-mcp to version 1.0.4", stderr: "" };
+    },
+    forwardSignals: false,
+  });
+
+  assert.equal(commands, 2);
+  const state = JSON.parse(await fsp.readFile(marketplaceUpdateStatePath(pluginData), "utf8"));
+  assert.equal(state.policyProvenance, "new-marketplace-install");
+});
+
+test("Claude stages marketplace updates once per day after a persisted attempt", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "memento-plugin-update-claude-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const pluginData = path.join(root, "plugin-data");
+  await initializeUpdateState({ pluginData, home: path.join(root, "home"), pluginDataExisted: false });
+  const calls = [];
+  const now = new Date("2026-08-10T00:00:00.000Z");
+  let persistedBeforeCommand = false;
+
+  const first = await runMarketplaceUpdateCheck({
+    pluginData,
+    now: () => now,
+    commandRunner: async (command, args, options) => {
+      calls.push({ command, args, timeoutMs: options.timeoutMs });
+      const state = JSON.parse(await fsp.readFile(marketplaceUpdateStatePath(pluginData), "utf8"));
+      persistedBeforeCommand ||= state.lastCheckedAt === now.toISOString();
+      return { stdout: "Updated memento@memento-mcp to version 1.0.4", stderr: "" };
+    },
+  });
+
+  assert.equal(first.result, "staged");
+  assert.equal(persistedBeforeCommand, true);
+  assert.deepEqual(calls.map(({ command, args }) => [command, ...args]), [
+    ["claude", "plugin", "marketplace", "update", "memento-mcp"],
+    ["claude", "plugin", "update", "memento@memento-mcp"],
+  ]);
+  assert.ok(calls.every(({ timeoutMs }) => timeoutMs > 0 && timeoutMs <= 30_000));
+
+  const second = await runMarketplaceUpdateCheck({
+    pluginData,
+    now: () => new Date("2026-08-10T23:59:59.000Z"),
+    commandRunner: async () => { throw new Error("daily throttle did not hold"); },
+  });
+  assert.equal(second.result, "staged");
+  assert.equal(calls.length, 2);
+});
+
+test("a live update lock and update failures leave the active server available", async (t) => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "memento-plugin-update-lock-"));
+  t.after(() => fsp.rm(root, { recursive: true, force: true }));
+  const pluginData = path.join(root, "plugin-data");
+  await initializeUpdateState({ pluginData, home: path.join(root, "home"), pluginDataExisted: false });
+  const lock = path.join(pluginData, "marketplace-update-state.lock");
+  await fsp.writeFile(lock, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }), { mode: 0o600 });
+  let called = false;
+  await runMarketplaceUpdateCheck({
+    pluginData,
+    now: () => new Date("2026-08-10T00:00:00.000Z"),
+    commandRunner: async () => { called = true; },
+  });
+  assert.equal(called, false);
+
+  await fsp.rm(lock);
+  const offline = Object.assign(new Error("offline"), { code: "ENETUNREACH" });
+  const state = await runMarketplaceUpdateCheck({
+    pluginData,
+    now: () => new Date("2026-08-11T01:00:00.000Z"),
+    commandRunner: async () => { throw offline; },
+  });
+  assert.equal(state.result, "offline");
+  assert.equal(state.currentVersion, RELEASE_VERSION);
+});
+
+test("the verified server starts before the background update check", async () => {
+  const events = [];
+  const child = new EventEmitter();
+  child.killed = false;
+  child.kill = () => { child.killed = true; };
+  const completed = startServerProcess("/verified/memento-mcp", {
+    spawnServer(binary) {
+      events.push(`spawn:${binary}`);
+      queueMicrotask(() => child.emit("spawn"));
+      return child;
+    },
+    backgroundCheck: async () => {
+      events.push("check");
+      throw new Error("offline");
+    },
+    notice: (message) => events.push(`notice:${message}`),
+  });
+  queueMicrotask(() => queueMicrotask(() => child.emit("exit", 0, null)));
+  await completed;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events.slice(0, 2), ["spawn:/verified/memento-mcp", "check"]);
+  assert.match(events[2], /^notice:memento plugin update check failed: offline$/);
+  assert.equal(child.killed, false);
+});
 
 test("plugin, marketplace, and launcher versions stay aligned", async () => {
   const pluginRoot = path.resolve(__dirname, "..");

--- a/scripts/verify-claude-plugin-release.mjs
+++ b/scripts/verify-claude-plugin-release.mjs
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function expectedVersion(refName) {
+  const match = /^server\/v(\d+\.\d+\.\d+)$/.exec(refName || "");
+  if (!match) throw new Error(`expected server/vX.Y.Z tag, got ${refName || "(empty)"}`);
+  return match[1];
+}
+
+async function readJSON(root, relativePath) {
+  return JSON.parse(await readFile(resolve(root, relativePath), "utf8"));
+}
+
+export async function validateClaudePluginRelease({ root, refName }) {
+  const expected = expectedVersion(refName);
+  const marketplacePath = ".claude-plugin/marketplace.json";
+  const pluginPath = "plugins/memento/.claude-plugin/plugin.json";
+  const launcherPath = "plugins/memento/bin/memento-launcher.cjs";
+  const [marketplace, plugin, launcher] = await Promise.all([
+    readJSON(root, marketplacePath),
+    readJSON(root, pluginPath),
+    readFile(resolve(root, launcherPath), "utf8"),
+  ]);
+  const entry = marketplace.plugins?.find((candidate) => candidate.name === "memento");
+  const launcherVersion = /const\s+RELEASE_VERSION\s*=\s*"([^"]+)"/.exec(launcher)?.[1];
+  const mismatches = [
+    [marketplacePath, entry?.version],
+    [pluginPath, plugin.version],
+    [launcherPath, launcherVersion],
+  ].filter(([, actual]) => actual !== expected);
+
+  if (mismatches.length > 0) {
+    throw new Error(mismatches.map(([path, actual]) => `${path}: found ${actual || "missing"}; expected ${expected}`).join("\n"));
+  }
+}
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  validateClaudePluginRelease({
+    root: option("--root") || process.cwd(),
+    refName: option("--ref") || process.env.GITHUB_REF_NAME,
+  }).catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/plugin-update-documentation.test.mjs
+++ b/test/plugin-update-documentation.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("native plugin documentation explains staged Claude marketplace updates", async () => {
+  const pluginReadme = await readFile(join(root, "plugins/memento/README.md"), "utf8");
+  const englishReadme = await readFile(join(root, "README.md"), "utf8");
+  const portugueseReadme = await readFile(join(root, "README.pt-BR.md"), "utf8");
+  const clients = await readFile(join(root, "docs/clients.md"), "utf8");
+
+  assert.match(pluginReadme, /plugin marketplace update memento-mcp/);
+  assert.match(pluginReadme, /once per 24 hours/i);
+  assert.match(pluginReadme, /new task|reload/i);
+  assert.match(pluginReadme, /marketplace-update\.json/);
+  assert.match(englishReadme, /staged plugin update/i);
+  assert.match(portugueseReadme, /atualiza[çc][ãa]o.*agendada/i);
+  assert.match(clients, /legacy marketplace.*opt/i);
+  assert.doesNotMatch(pluginReadme, /0\.8\.0/);
+  assert.doesNotMatch(englishReadme, /remain version-pinned and must be updated through `\/plugin` commands/i);
+  assert.doesNotMatch(portugueseReadme, /continuam fixadas por versão e devem ser atualizadas pelos comandos `\/plugin`/i);
+});

--- a/test/release-workflows.test.mjs
+++ b/test/release-workflows.test.mjs
@@ -60,6 +60,22 @@ test("release workflow always builds raw macOS binaries and optionally notarizes
   );
 });
 
+test("release workflow validates the native Claude plugin before builds or publication", async () => {
+  const workflow = await readFile(releaseWorkflowPath, "utf8");
+  const validation = workflow.match(/  validate-claude-plugin-release:[\s\S]*?\n  build-binaries:/)?.[0];
+  const build = workflow.match(/  build-binaries:[\s\S]*?\n  package-deb:/)?.[0];
+  const deb = workflow.match(/  package-deb:[\s\S]*?\n  package-macos-pkg:/)?.[0];
+  const macos = workflow.match(/  package-macos-pkg:[\s\S]*?\n  publish:/)?.[0];
+  const publish = workflow.match(/  publish:[\s\S]*$/)?.[0];
+
+  assert.ok(validation, "plugin release validation job must exist before binary builds");
+  assert.match(validation, /node scripts\/verify-claude-plugin-release\.mjs/);
+  assert.match(build, /needs: validate-claude-plugin-release/);
+  assert.match(deb, /needs: validate-claude-plugin-release/);
+  assert.match(macos, /needs: validate-claude-plugin-release/);
+  assert.match(publish, /needs: \[validate-claude-plugin-release, build-binaries, package-deb, package-macos-pkg\]/);
+});
+
 test("server/latest mirrors verified versioned assets without rebuilding", async () => {
   const workflow = await readFile(latestWorkflowPath, "utf8");
 

--- a/test/verify-claude-plugin-release.test.mjs
+++ b/test/verify-claude-plugin-release.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const verifier = join(root, "scripts", "verify-claude-plugin-release.mjs");
+
+async function writeReleaseFixture(root, versions = {}) {
+  const version = "1.2.3";
+  await mkdir(join(root, ".claude-plugin"), { recursive: true });
+  await mkdir(join(root, "plugins", "memento", ".claude-plugin"), { recursive: true });
+  await mkdir(join(root, "plugins", "memento", "bin"), { recursive: true });
+  await writeFile(join(root, ".claude-plugin", "marketplace.json"), JSON.stringify({
+    plugins: [{ name: "memento", version: versions.marketplace || version }],
+  }));
+  await writeFile(join(root, "plugins", "memento", ".claude-plugin", "plugin.json"), JSON.stringify({
+    name: "memento",
+    version: versions.plugin || version,
+  }));
+  await writeFile(join(root, "plugins", "memento", "bin", "memento-launcher.cjs"),
+    `const RELEASE_VERSION = "${versions.launcher || version}";\n`);
+}
+
+function verifyFixture(fixture, refName = "server/v1.2.3") {
+  return spawnSync(process.execPath, [verifier, "--root", fixture, "--ref", refName], { encoding: "utf8" });
+}
+
+test("release contract accepts an aligned native Claude plugin", async (t) => {
+  const fixture = await mkdtemp(join(tmpdir(), "memento-plugin-release-contract-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  await writeReleaseFixture(fixture);
+
+  const result = verifyFixture(fixture);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const [source, versions, expectedPath] of [
+  ["marketplace", { marketplace: "1.2.2" }, ".claude-plugin/marketplace.json"],
+  ["plugin", { plugin: "1.2.2" }, "plugins/memento/.claude-plugin/plugin.json"],
+  ["launcher", { launcher: "1.2.2" }, "plugins/memento/bin/memento-launcher.cjs"],
+]) {
+  test(`release contract rejects stale ${source} version`, async (t) => {
+    const fixture = await mkdtemp(join(tmpdir(), "memento-plugin-release-contract-"));
+    t.after(() => rm(fixture, { recursive: true, force: true }));
+    await writeReleaseFixture(fixture, versions);
+
+    const result = verifyFixture(fixture);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, new RegExp(`${expectedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*expected 1\\.2\\.3`, "s"));
+  });
+}
+
+test("release contract rejects a non-server semantic tag", async (t) => {
+  const fixture = await mkdtemp(join(tmpdir(), "memento-plugin-release-contract-"));
+  t.after(() => rm(fixture, { recursive: true, force: true }));
+  await writeReleaseFixture(fixture);
+
+  const result = verifyFixture(fixture, "server/latest");
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /expected server\/vX\.Y\.Z tag/);
+});


### PR DESCRIPTION
## What

Adds a release-time contract check that keeps the native Claude plugin marketplace metadata, manifest, and launcher version aligned with every `server/vX.Y.Z` release. The launcher now performs a bounded, non-blocking daily marketplace update check and stages any update for the next Claude task.

## Why

The standalone Memento binary could be current while the Claude Desktop task-local plugin remained pinned to an older server (for example 0.8.0). The binary release flow had no invariant ensuring the plugin artifacts kept pace.

## How

- Gate server release assets and publication on plugin-version validation.
- Derive the Claude plugin lifecycle test version from its manifest.
- Stage marketplace/plugin updates in the background after the MCP server starts, with an explicit opt-out and safe legacy-cache default.
- Document activation and add regression coverage for release metadata, updater behavior, and documentation.

## Validation

- `make test`
- `make plugin-test`
- `node --test test/verify-claude-plugin-release.test.mjs test/release-workflows.test.mjs test/plugin-update-documentation.test.mjs`
- `actionlint`
- `git diff --check`