### PR TITLE
fix: report index size in status instead of per-pass counts

### DIFF
--- a/internal/indexing/indexer.go
+++ b/internal/indexing/indexer.go
@@ -164,6 +164,7 @@ func New(cfg Config) (*Indexer, error) {
 		}
 	}
 	idx.rebuildTrigramIndex()
+	idx.status = idx.statusFromManifestLocked()
 	return idx, nil
 }
 
@@ -374,6 +375,29 @@ func (i *Indexer) Status() Status {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return i.status
+}
+
+// indexSizeLocked reports what the index currently holds. The manifest is the
+// same source outline, search, and DebugInfo read from, so status stays
+// consistent with the answers those tools return. Counting only the files a
+// pass rewrote would report zero whenever the index is already current.
+func (i *Indexer) indexSizeLocked() (files int, bytes int64) {
+	return len(i.manifest.Files), i.manifest.TotalBytes
+}
+
+// statusFromManifestLocked rebuilds status for an index loaded from disk, so a
+// process that reopens a populated store reports it before any pass runs.
+func (i *Indexer) statusFromManifestLocked() Status {
+	files, bytes := i.indexSizeLocked()
+	if files == 0 {
+		return Status{}
+	}
+	return Status{
+		Ready:         true,
+		LastIndexedAt: i.manifest.UpdatedAt,
+		FilesIndexed:  files,
+		BytesIndexed:  bytes,
+	}
 }
 
 type DebugInfo struct {
@@ -889,8 +913,6 @@ func (i *Indexer) indexAll(ctx context.Context) error {
 	totalBytes = i.manifest.TotalBytes
 	i.mu.Unlock()
 
-	bytesIndexed := int64(0)
-	filesIndexed := 0
 	partial := false
 
 	for _, c := range candidates {
@@ -924,8 +946,6 @@ func (i *Indexer) indexAll(ctx context.Context) error {
 		}
 		if ok {
 			totalBytes += delta
-			bytesIndexed += max64(delta, 0)
-			filesIndexed++
 		}
 	}
 
@@ -936,10 +956,11 @@ func (i *Indexer) indexAll(ctx context.Context) error {
 
 	i.mu.Lock()
 	lastError := i.status.Error
+	files, bytesIndexed := i.indexSizeLocked()
 	i.status = Status{
 		Ready:         true,
 		LastIndexedAt: time.Now().UTC().Format(time.RFC3339),
-		FilesIndexed:  filesIndexed,
+		FilesIndexed:  files,
 		BytesIndexed:  bytesIndexed,
 		Partial:       partial,
 		Error:         lastError,
@@ -1632,13 +1653,6 @@ func isPHPIndexExtension(ext string) bool {
 
 func min(a, b int) int {
 	if a < b {
-		return a
-	}
-	return b
-}
-
-func max64(a, b int64) int64 {
-	if a > b {
 		return a
 	}
 	return b

--- a/internal/indexing/status_report_test.go
+++ b/internal/indexing/status_report_test.go
@@ -1,0 +1,104 @@
+package indexing
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeStatusFixture(t *testing.T, root string) {
+	t.Helper()
+	files := map[string]string{
+		"alpha.go": "package alpha\n\nfunc Alpha() string { return \"alpha\" }\n",
+		"beta.go":  "package beta\n\nfunc Beta() string { return \"beta\" }\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// A re-index pass that finds every file already current must still report the
+// size of the index, not the number of files rewritten during that pass.
+func TestStatusReportsIndexSizeAfterNoOpReindex(t *testing.T) {
+	root := t.TempDir()
+	store := t.TempDir()
+	writeStatusFixture(t, root)
+
+	idx, err := New(Config{RootAbs: root, StoreDir: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	idx.Start(ctx)
+
+	if err := idx.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	first := idx.Status()
+	if first.FilesIndexed != 2 {
+		t.Fatalf("first pass FilesIndexed = %d, want 2", first.FilesIndexed)
+	}
+
+	// Nothing changed on disk, so this pass rewrites no files.
+	if err := idx.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	second := idx.Status()
+	if second.FilesIndexed != 2 {
+		t.Fatalf("no-op reindex FilesIndexed = %d, want 2", second.FilesIndexed)
+	}
+	if second.BytesIndexed != first.BytesIndexed {
+		t.Fatalf("no-op reindex BytesIndexed = %d, want %d", second.BytesIndexed, first.BytesIndexed)
+	}
+	if !second.Ready {
+		t.Fatal("no-op reindex Ready = false, want true")
+	}
+}
+
+// A process that reopens an existing store must report the persisted index
+// before any pass runs; the manifest already answers outline and search.
+func TestStatusReflectsLoadedManifestBeforeIndexPass(t *testing.T) {
+	root := t.TempDir()
+	store := t.TempDir()
+	writeStatusFixture(t, root)
+
+	warm, err := New(Config{RootAbs: root, StoreDir: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	warm.Start(ctx)
+	if err := warm.IndexAll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	want := warm.Status()
+	cancel()
+
+	reopened, err := New(Config{RootAbs: root, StoreDir: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := reopened.Status()
+	if got.FilesIndexed != want.FilesIndexed {
+		t.Fatalf("reopened FilesIndexed = %d, want %d", got.FilesIndexed, want.FilesIndexed)
+	}
+	if got.BytesIndexed != want.BytesIndexed {
+		t.Fatalf("reopened BytesIndexed = %d, want %d", got.BytesIndexed, want.BytesIndexed)
+	}
+	if !got.Ready {
+		t.Fatal("reopened Ready = false, want true")
+	}
+	if got.LastIndexedAt == "" {
+		t.Fatal("reopened LastIndexedAt is empty, want persisted timestamp")
+	}
+	// DebugInfo derives its count from the manifest and is the cross-check
+	// that the index really does hold these files.
+	if debug := reopened.DebugInfo(); debug.FilesIndexed != want.FilesIndexed {
+		t.Fatalf("reopened DebugInfo.FilesIndexed = %d, want %d", debug.FilesIndexed, want.FilesIndexed)
+	}
+}


### PR DESCRIPTION
repo_index_status reported filesIndexed 0 on a populated index while outline and search answered correctly. Status cached counters written only at the end of an index pass, counting files rewritten by that pass rather than files held in the index. Two paths hit zero:

- A pass over an already-current index rewrites nothing, so it overwrote status with zero.
- New() loaded the manifest but never seeded status, so a restarted server reported zero until a pass completed.

Derive the size fields from the manifest, the same source outline, search, and DebugInfo read from. Seed status from the manifest on load so a reopened store reports itself before any pass runs. Partial stays per-pass. Drop the dead per-pass counters and max64.